### PR TITLE
Control Centre tile system: layout menu overflow fix + Settings sheet (JP-253)

### DIFF
--- a/docs-site/guide/layout-modes.md
+++ b/docs-site/guide/layout-modes.md
@@ -36,6 +36,12 @@ Change layout any time — there are three ways:
 - The keyboard: <kbd>Cmd/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>1</kbd>–<kbd>4</kbd>
 - The command palette (<kbd>Cmd/Ctrl</kbd> + <kbd>K</kbd>) → "Switch to … layout"
 
+The layout chip opens the **View menu**: the four layouts as preview tiles, with
+the active one marked, and below them a tile per panel to show or hide it. That
+panel row is the quickest way to bring back a panel you've hidden — the
+Navigator in particular starts hidden in every layout. The menu narrows and
+scrolls to fit small windows, so it stays usable at any size.
+
 Your layout is an **app-level** setting — a single active mode for the whole
 editor, not a per-document one. Customizations you make to one layout (say, moving
 the properties panel) stay scoped to that layout and don't disturb the others.

--- a/docs-site/guide/settings.md
+++ b/docs-site/guide/settings.md
@@ -1,103 +1,126 @@
 ---
 title: Settings
-description: DocuShark settings — appearance, theme, collaboration server, storage, and editor preferences.
+description: DocuShark settings — appearance, theme, style profiles, backup, and editor preferences.
 ---
 
 # Settings
 
-Access settings via the **Settings** button in the toolbar.
+Open settings with the **Settings** button in the toolbar. Settings opens as a
+full-screen sheet over your document; **Close** (top right) or `Esc` returns you
+to where you were.
+
+Controls are grouped into **tiles**. Each tile leads with an icon, names one
+setting, and carries its own control and help text — the same tiles you see in
+the [layout menu](./layout-modes#switching-layouts), so the two work the same way.
+
+Five tabs, down the left:
+
+| Tab | What lives there |
+|---|---|
+| **General** | Shape defaults and display toggles |
+| **Appearance** | Theme, writing, interface, and panel layout |
+| **Style Profiles** | What a new style profile captures |
+| **Backup & Restore** | Export and restore your data |
+| **About** | Build identity for the app and the workspace it's connected to |
+
+::: tip Where did Documents, Storage and Shape Libraries go?
+They're first-class surfaces now, not settings tabs — you'll find them on
+**Documents Home** rather than in this window.
+:::
 
 ## General
 
 | Setting | Options | Description |
 |---------|---------|-------------|
-| Theme | System / Light / Dark | Color theme for the application |
-| Default Shape Style Profile | Dropdown | Style profile applied to new shapes |
-| Default Connector Type | Orthogonal / Straight | Default routing for new connectors |
-| Show Static Properties | On/Off | Show read-only properties in Property Panel |
-| Hide Default Style Profiles | On/Off | Hide the 5 built-in profiles from the Style Profile list |
+| Default style profile | Dropdown | Style profile applied to new shapes |
+| Static properties | On/Off | Show read-only properties (like ID) in the Property Panel |
+| Hide default style profiles | On/Off | Show only your custom profiles in the Property Panel |
+| Minimap | On/Off | Minimap overlay for navigating large canvases (experimental) |
+| Auto-focus on layer click | On/Off | Pan the camera to a shape when you click it in the Layers panel |
 
-### Style Profile Settings
+**Reset settings** returns everything on this tab to its shipped value.
 
-| Setting | Options | Description |
-|---------|---------|-------------|
-| Save Icon Style to Profile | On/Off | Include icon settings when saving a style profile |
-| Save Label Style to Profile | On/Off | Include label settings when saving a style profile |
+## Appearance
 
-## Canvas
-
-### Minimap
+### Theme
 
 | Setting | Options | Description |
 |---------|---------|-------------|
-| Show Minimap | On/Off | Display minimap overlay on canvas (experimental) |
+| Base | System / Light / Dark | The light or dark foundation |
+| Presets | Preset chips | Start from a preset, then fine-tune |
+| Primary / CTA / Surface / Text | Color | Individual color slots. Unset slots read **Auto** and are derived for you |
 
-### Layer Panel
+Light and dark are customized **independently** — switch Base to edit the other
+one. **Surprise me** generates a random but legible theme, and **Reset … theme**
+returns the base you're editing to its default.
 
-| Setting | Options | Description |
-|---------|---------|-------------|
-| Snap to Layer on Click | On/Off | Automatically pan to a shape when clicking it in the Layer Panel |
+Color slots warn inline when a choice falls below a readable contrast ratio.
 
-## Documents
-
-The Documents section of settings provides document management:
-
-- **Create** new documents
-- **Import/Export** documents as JSON
-- View and manage **local documents**
-- View and manage **remote/cached cloud documents** (when collaboration is active)
-- **Delete** documents (sent to trash with configurable retention)
-
-## Shape Libraries
-
-Manage custom shape libraries:
-
-- **Create** new libraries
-- **Rename** and **delete** custom libraries
-- **Export** libraries as JSON for sharing
-- **Import** libraries from JSON files
-
-Built-in libraries (Basic, Flowchart, UML, ERD) cannot be deleted.
-
-## Storage
-
-View and manage stored data:
-
-- **Blob storage**: View stored images and icons with metadata
-- **Garbage collection**: Clean up orphaned blobs (icons are protected by default)
-- Storage usage statistics
-
-When you're signed in to a workspace, the storage ring on Documents Home breaks
-its usage into three parts, one arc each:
-
-| Part | What it holds |
-|---|---|
-| **Documents** | Your documents' content, including anything you've published |
-| **Files** | Images, icons, and files you've embedded |
-| **Configuration** | [Style profiles](./styling#using-your-profiles-on-more-than-one-device) synced across your devices |
-
-Hover the ring for the exact amount in each part, or select it to open Storage
-for the full breakdown.
-
-Configuration is typically a few kilobytes — it's counted separately so every
-part of your workspace is accounted for, not because settings take meaningful
-space.
-
-## Workspace (Collaboration)
-
-Connecting to a workspace happens from **Documents Home**, not this Settings window — look for the Cloud panel. From there you can sign in with DocuShark Cloud, see your signed-in identity, disconnect, and (under Advanced) point at a [self-hosted setup](../developer/self-hosting) instead.
-
-For how collaboration works and how to connect, see
-**[Collaboration](./collaboration)**.
-
-## PDF Export
-
-Configure PDF export defaults:
+### Writing
 
 | Setting | Options | Description |
 |---------|---------|-------------|
-| Page Size | A4, Letter, A3, Tabloid | Document page size |
-| Orientation | Portrait / Landscape | Page orientation |
-| DPI | Standard (72), High (150), Print (300) | Render quality |
-| Page Numbers | On/Off | Include page numbers |
-| Cover Page | On/Off | Include a cover page with logo, title, author, etc. |
+| Prose background | Preset chips | The backdrop behind the writing area |
+| Caret style | Bar / Block | The text cursor shape |
+| Smooth writing | On/Off | Glide the caret between positions. Off automatically when motion is reduced |
+| Rounded tables | On/Off | Off gives square, grid-style tables |
+| Caret color | Color | Defaults to the theme text color |
+| Spellcheck | Custom / System / Off | Custom uses DocuShark's dictionary and "Add to dictionary"; System uses your browser or OS checker. Only one runs at a time |
+
+### Interface
+
+| Setting | Options | Description |
+|---------|---------|-------------|
+| Interface size | 90–125% | Scales the whole interface. The canvas and your diagrams are not affected |
+| Grid opacity | 0–100% | How visible the canvas grid is; 0 hides it |
+| Density | Compact / Normal / Spacious | Compact fits more on screen; Spacious gives larger targets |
+| Motion | System / Reduced / Full | System follows your device's accessibility setting |
+| Glass chrome | On/Off | Translucent, blurred panels. Off is flat and opaque — lighter to render |
+| Mobile preview | On/Off | Experimental small-screen layout. See [Mobile preview](./mobile-preview) |
+| DocuShark title bar | On/Off | Desktop app only. Replaces your system title bar; restarts to apply |
+
+Interface size and Grid opacity are drag tiles — drag anywhere on the tile, or
+focus it and use the arrow keys.
+
+### Layout
+
+The panel-arrangement editor is embedded here: per-layout dock positions for
+each panel, and a reset. See **[Layout modes](./layout-modes)**.
+
+**Reset appearance** returns theme, motion, density, interface size and layout
+customization to their defaults.
+
+## Style Profiles
+
+What gets captured when you create a new style profile from a shape.
+
+| Setting | Options | Description |
+|---------|---------|-------------|
+| Icon style | On/Off | Icon ID, size and padding |
+| Label style | On/Off | Label font size, color, background and offset |
+
+These apply to **new** profiles only — existing profiles keep the properties
+they were saved with.
+
+## Backup & Restore
+
+Export your documents, style profiles and preferences to a single archive, and
+restore from one. See **[Export & import](./export-import)** for the full workflow.
+
+## About
+
+Build identity for the running app — version, commit, build time and platform —
+and, when you're connected to a workspace, the same for its server.
+
+## Related settings elsewhere
+
+Some things that feel like settings live closer to where you use them:
+
+- **Connecting to a workspace** — Documents Home, in the Cloud panel. See
+  [Collaboration](./collaboration).
+- **Storage usage and cleanup** — Documents Home. The storage ring breaks usage
+  into Documents, Files and Configuration; select it for the full breakdown.
+- **Default connector routing** — remembered from your last choice in the canvas
+  toolbar's connector dropdown, rather than set here.
+- **PDF export options** (page size, orientation, DPI, page numbers, cover page)
+  — chosen in the export dialog at export time. See [Export & import](./export-import).

--- a/src/index.css
+++ b/src/index.css
@@ -380,6 +380,14 @@ html {
   --grad-primary: linear-gradient(145deg, var(--navy-600) 0%, var(--navy-700) 45%, var(--navy-900) 100%);
   --grad-fill: linear-gradient(to top, var(--navy-900) 0%, var(--navy-700) 60%, var(--navy-600) 100%);
 
+  /* Room light on a full-bleed glass sheet. A sheet that covers the viewport
+     has nothing left around it to refract, so it carries its own soft brand
+     washes — otherwise the blur has nothing to say and it reads as flat tint. */
+  --sheet-wash:
+    radial-gradient(1200px 620px at 12% -8%, rgba(31, 51, 84, 0.07), transparent 62%),
+    radial-gradient(900px 520px at 92% 4%, rgba(201, 162, 98, 0.09), transparent 60%),
+    radial-gradient(760px 700px at 68% 108%, rgba(31, 51, 84, 0.05), transparent 65%);
+
   /* Motion. The spring overshoots slightly — that small bounce is the
      difference between "a class toggled" and "a switch was thrown". */
   --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -404,6 +412,10 @@ html {
   --shadow-tile-hover: 0 1px 1px rgba(0, 0, 0, 0.3), 0 10px 24px -6px rgba(0, 0, 0, 0.5);
   --grad-primary: linear-gradient(145deg, #f0dcae 0%, var(--brand-gold-soft) 45%, var(--brand-gold) 100%);
   --grad-fill: linear-gradient(to top, var(--brand-gold) 0%, var(--brand-gold-soft) 70%, #f0dcae 100%);
+  --sheet-wash:
+    radial-gradient(1200px 620px at 12% -8%, rgba(43, 70, 110, 0.28), transparent 62%),
+    radial-gradient(900px 520px at 92% 4%, rgba(201, 162, 98, 0.07), transparent 58%),
+    radial-gradient(760px 700px at 68% 108%, rgba(31, 51, 84, 0.22), transparent 65%);
 }
 
 /* Appearance → Glass, off. Every token resolves to the opaque equivalent. */
@@ -422,4 +434,5 @@ html {
   --shadow-tile-hover: none;
   --grad-primary: var(--color-primary);
   --grad-fill: var(--color-primary);
+  --sheet-wash: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -329,3 +329,97 @@ html {
 [data-density='spacious'] {
   --density-mult: 1.15;
 }
+
+/* ===========================================================================
+ * Glass + motion tokens (JP-253)
+ * ---------------------------------------------------------------------------
+ * The tile system's surface vocabulary, consumed only by floating chrome (the
+ * settings sheet, the layout menu) and the tiles inside it. Semantic and
+ * mode-flipped like the rest of the token set; components never reach for the
+ * raw ramps.
+ *
+ * Two rules this encodes, both learned by measuring rather than guessing:
+ *
+ * 1. ONE blurred surface per floating panel. `backdrop-filter` costs a backdrop
+ *    read-back plus a blur pass *per element*, and a nested one re-blurs its
+ *    already-blurred parent. Measured with an animating backdrop: 2 blur
+ *    surfaces = 7.15ms/frame, 32 (blur on every tile) = 9.46ms/frame — for no
+ *    visible difference. Tiles therefore use plain translucent fills over the
+ *    panel's single blur.
+ * 2. `[data-glass="off"]` resolves every token here back to today's opaque
+ *    values, so the Appearance opt-out is one attribute on <html> and there is
+ *    no second styling path to maintain.
+ * ======================================================================== */
+:root {
+  --glass-blur: 20px;
+  --glass-saturate: 180%;
+
+  /* The floating panel itself. */
+  --glass-surface: rgba(249, 246, 238, 0.72);
+  --glass-border: rgba(255, 255, 255, 0.6);
+
+  /* A tile: a raised plate ON the panel, so it reads as stacked glass. */
+  --glass-tile: rgba(255, 255, 255, 0.5);
+  --glass-tile-hover: rgba(255, 255, 255, 0.78);
+  --glass-tile-border: rgba(255, 255, 255, 0.55);
+
+  /* The 1px specular line along a top-lit glass edge. */
+  --glass-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+  --glass-highlight-soft: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+
+  /* Layered elevation. One shadow reads as a sticker; three read as an object
+     above a surface (contact + ambient + cast). */
+  --shadow-float:
+    0 1px 1px rgba(14, 28, 48, 0.05), 0 8px 24px -8px rgba(14, 28, 48, 0.18),
+    0 28px 64px -16px rgba(14, 28, 48, 0.24);
+  --shadow-tile: 0 1px 1px rgba(14, 28, 48, 0.04), 0 2px 8px -3px rgba(14, 28, 48, 0.1);
+  --shadow-tile-hover:
+    0 1px 1px rgba(14, 28, 48, 0.05), 0 8px 20px -6px rgba(14, 28, 48, 0.18);
+
+  /* Accent fills gradate rather than sitting flat — light falls off. */
+  --grad-primary: linear-gradient(145deg, var(--navy-600) 0%, var(--navy-700) 45%, var(--navy-900) 100%);
+  --grad-fill: linear-gradient(to top, var(--navy-900) 0%, var(--navy-700) 60%, var(--navy-600) 100%);
+
+  /* Motion. The spring overshoots slightly — that small bounce is the
+     difference between "a class toggled" and "a switch was thrown". */
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --dur-fast: 0.16s;
+  --dur-med: 0.28s;
+  --dur-slow: 0.45s;
+}
+
+[data-theme='dark'] {
+  --glass-surface: rgba(14, 28, 48, 0.58);
+  --glass-border: rgba(214, 224, 240, 0.14);
+  --glass-tile: rgba(214, 224, 240, 0.055);
+  --glass-tile-hover: rgba(214, 224, 240, 0.11);
+  --glass-tile-border: rgba(214, 224, 240, 0.1);
+  --glass-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  --glass-highlight-soft: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  --shadow-float:
+    0 1px 1px rgba(0, 0, 0, 0.3), 0 10px 28px -8px rgba(0, 0, 0, 0.55),
+    0 32px 72px -16px rgba(0, 0, 0, 0.65);
+  --shadow-tile: 0 1px 1px rgba(0, 0, 0, 0.25), 0 2px 8px -3px rgba(0, 0, 0, 0.35);
+  --shadow-tile-hover: 0 1px 1px rgba(0, 0, 0, 0.3), 0 10px 24px -6px rgba(0, 0, 0, 0.5);
+  --grad-primary: linear-gradient(145deg, #f0dcae 0%, var(--brand-gold-soft) 45%, var(--brand-gold) 100%);
+  --grad-fill: linear-gradient(to top, var(--brand-gold) 0%, var(--brand-gold-soft) 70%, #f0dcae 100%);
+}
+
+/* Appearance → Glass, off. Every token resolves to the opaque equivalent. */
+[data-glass='off'] {
+  --glass-blur: 0px;
+  --glass-saturate: 100%;
+  --glass-surface: var(--bg-primary);
+  --glass-border: var(--border-color);
+  --glass-tile: var(--bg-tertiary);
+  --glass-tile-hover: var(--bg-hover);
+  --glass-tile-border: transparent;
+  --glass-highlight: none;
+  --glass-highlight-soft: none;
+  --shadow-float: var(--shadow-xl);
+  --shadow-tile: none;
+  --shadow-tile-hover: none;
+  --grad-primary: var(--color-primary);
+  --grad-fill: var(--color-primary);
+}

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -107,6 +107,37 @@ describe('uiPreferencesStore — rounded tables', () => {
   });
 });
 
+describe('uiPreferencesStore — glass chrome', () => {
+  it('defaults to on (opt-out)', () => {
+    expect(useUIPreferencesStore.getState().appearancePrefs.glass).toBe(true);
+  });
+
+  it('setGlass flips the preference', () => {
+    useUIPreferencesStore.getState().setGlass(false);
+    expect(useUIPreferencesStore.getState().appearancePrefs.glass).toBe(false);
+    useUIPreferencesStore.getState().setGlass(true);
+    expect(useUIPreferencesStore.getState().appearancePrefs.glass).toBe(true);
+  });
+
+  it('leaves an existing appearance choice alone when migrating in', async () => {
+    // A v13 payload predates `glass`; the migration must add it without
+    // disturbing what the user already picked.
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 13,
+        state: { appearancePrefs: { density: 'compact', uiScale: 1.1 } },
+      })
+    );
+    const { useUIPreferencesStore: fresh } = await import('./uiPreferencesStore');
+    await fresh.persist.rehydrate();
+    const prefs = fresh.getState().appearancePrefs;
+    expect(prefs.glass).toBe(true);
+    expect(prefs.density).toBe('compact');
+    expect(prefs.uiScale).toBe(1.1);
+  });
+});
+
 describe('uiPreferencesStore — spellcheck mode', () => {
   it('defaults to the custom (built-in) checker', () => {
     expect(useUIPreferencesStore.getState().appearancePrefs.spellcheck).toBe('custom');
@@ -297,6 +328,7 @@ describe('uiPreferencesStore — migration', () => {
       caretColor: null,
       spellcheck: 'custom',
       roundedTables: true,
+      glass: true,
     });
     // Layout from the older payload is untouched.
     expect(state.layout.defaultMode).toBe('power');
@@ -328,6 +360,7 @@ describe('uiPreferencesStore — migration', () => {
       caretColor: null,
       spellcheck: 'custom',
       roundedTables: true,
+      glass: true,
     });
   });
 
@@ -356,6 +389,7 @@ describe('uiPreferencesStore — migration', () => {
       caretColor: null,
       spellcheck: 'custom',
       roundedTables: true,
+      glass: true,
     });
   });
 
@@ -468,6 +502,7 @@ describe('uiPreferencesStore — appearance slice', () => {
       caretColor: null,
       spellcheck: 'custom',
       roundedTables: true,
+      glass: true,
     });
   });
 

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -102,6 +102,17 @@ export interface AppearancePrefs {
   spellcheck: SpellcheckMode;
   /** Rounded corners on prose tables. Opt-out — on by default (JP-416). */
   roundedTables: boolean;
+  /**
+   * Translucent ("glass") chrome on floating surfaces — the settings sheet and
+   * the layout menu. Opt-out; on by default (JP-253).
+   *
+   * `backdrop-filter` makes the compositor read back and blur what is behind the
+   * surface, and re-run whenever that changes. One blurred surface per floating
+   * panel is cheap; the escape hatch exists because the Tauri shell runs
+   * WebKitGTK, where this is historically weaker than Chromium. Turning it off
+   * resolves every glass token back to the opaque surfaces.
+   */
+  glass: boolean;
 }
 
 /**
@@ -258,6 +269,8 @@ export interface UIPreferencesActions {
   setSmoothCaret: (smoothCaret: boolean) => void;
   /** Toggle rounded corners on prose tables. */
   setRoundedTables: (roundedTables: boolean) => void;
+  /** Toggle translucent ("glass") chrome on floating surfaces. */
+  setGlass: (glass: boolean) => void;
   /** Set the interface size multiplier (clamped to [0.9, 1.25]). */
   setUiScale: (uiScale: number) => void;
   /** Set the prose editor background preset. */
@@ -326,6 +339,7 @@ const initialAppearancePrefs: AppearancePrefs = {
   caretColor: null,
   spellcheck: 'custom',
   roundedTables: true,
+  glass: true,
 };
 
 /** Clamp a UI-scale value into the supported range. */
@@ -640,6 +654,10 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         set({ appearancePrefs: { ...get().appearancePrefs, roundedTables } });
       },
 
+      setGlass: (glass) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, glass } });
+      },
+
       setCaretColor: (caretColor) => {
         set({ appearancePrefs: { ...get().appearancePrefs, caretColor } });
       },
@@ -654,7 +672,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 13,
+      version: 14,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         rotationUnit: state.rotationUnit,
@@ -813,6 +831,14 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         // (opt-out) without clobbering existing appearance choices. (The `merge`
         // below also backstops this.)
         if (fromVersion < 13) {
+          next['appearancePrefs'] = {
+            ...initialAppearancePrefs,
+            ...((next['appearancePrefs'] as Partial<AppearancePrefs> | undefined) ?? {}),
+          };
+        }
+        // v13 → v14: appearance slice gained `glass` (JP-253). Default on
+        // (opt-out), preserving every existing appearance choice.
+        if (fromVersion < 14) {
           next['appearancePrefs'] = {
             ...initialAppearancePrefs,
             ...((next['appearancePrefs'] as Partial<AppearancePrefs> | undefined) ?? {}),

--- a/src/ui/SettingsModal.css
+++ b/src/ui/SettingsModal.css
@@ -24,14 +24,27 @@
   }
 }
 
+/* Settings is a full-bleed glass SHEET, not a centred modal window (JP-253).
+   The old 850x620 dialog gave the tile mosaic three columns and a scrollbar;
+   the sheet gives it the viewport, which is the whole point of a mosaic.
+   Content is still held to a readable column width below — full-bleed is about
+   the surface, not about stretching controls across a 27" monitor.
+
+   The sheet is the ONE blurred surface in Settings; tiles inside it are plain
+   translucent fills. Each backdrop-filter element costs its own backdrop
+   read-back and blur pass, and a nested one re-blurs its already-blurred
+   parent; measured at 7.15ms/frame for one blurred surface vs 9.46ms with the
+   blur repeated on every tile, for no visible difference. */
 .settings-modal {
-  background: var(--bg-primary);
-  border-radius: 16px;
-  box-shadow: var(--shadow-xl), 0 0 0 1px var(--border-color);
-  width: 850px;
-  max-width: 92vw;
-  height: 620px;
-  max-height: 88vh;
+  background-color: var(--glass-surface);
+  /* A sheet that covers the viewport has nothing around it left to refract, so
+     it carries its own brand wash on top of the blurred app beneath. */
+  background-image: var(--sheet-wash);
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  width: 100%;
+  height: 100%;
+  border-radius: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -41,21 +54,12 @@
 @keyframes settings-modal-in {
   from {
     opacity: 0;
-    transform: scale(0.96) translateY(8px);
+    transform: scale(1.01);
   }
   to {
     opacity: 1;
-    transform: scale(1) translateY(0);
+    transform: scale(1);
   }
-}
-
-.settings-modal.is-fullscreen {
-  width: 100vw;
-  max-width: none;
-  height: 100vh;
-  max-height: none;
-  border-radius: 0;
-  transition: border-radius 0.2s ease;
 }
 
 .settings-modal-header-actions {
@@ -64,35 +68,25 @@
   gap: 4px;
 }
 
-.settings-modal-fullscreen {
-  width: 34px;
-  height: 34px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: none;
-  border-radius: 8px;
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.settings-modal-fullscreen:hover {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  transform: scale(1.05);
-}
-
 .settings-modal-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 18px 24px;
-  background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
-  border-bottom: 1px solid var(--border-color);
+  /* A faint top-down sheen, not an opaque fill — an opaque header would punch a
+     solid band through the glass sheet. */
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.28), transparent);
+  border-bottom: 1px solid var(--glass-tile-border);
   flex-shrink: 0;
+}
+
+[data-theme='dark'] .settings-modal-header {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), transparent);
+}
+
+[data-glass='off'] .settings-modal-header {
+  background: var(--bg-primary);
+  border-bottom-color: var(--border-color);
 }
 
 .settings-modal-header h2 {
@@ -103,26 +97,45 @@
   letter-spacing: -0.02em;
 }
 
+/* A full-bleed sheet covers the app, so "how do I get out of this" has to be
+   unmissable — a 34px transparent glyph in a corner was fine on an 850px dialog
+   floating over visible context, and is not fine here. Given a real surface,
+   border and label it reads as the exit at a glance. */
 .settings-modal-close {
-  width: 34px;
-  height: 34px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: none;
-  border-radius: 8px;
-  background: transparent;
+  gap: var(--space-2);
+  height: var(--control-height-xl);
+  padding: 0 var(--space-3);
+  border: 1px solid var(--glass-tile-border);
+  border-radius: var(--radius-lg);
+  background: var(--glass-tile);
+  box-shadow: var(--shadow-tile), var(--glass-highlight-soft);
   color: var(--text-secondary);
-  font-size: 22px;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  line-height: 1;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition:
+    background-color var(--dur-med) var(--ease-out),
+    color var(--dur-med) var(--ease-out),
+    border-color var(--dur-med) var(--ease-out);
+}
+
+.settings-modal-close__glyph {
+  font-size: 18px;
+  line-height: 1;
 }
 
 .settings-modal-close:hover {
   background: var(--danger-bg);
+  border-color: var(--danger);
   color: var(--danger-text);
-  transform: scale(1.05);
+}
+
+.settings-modal-close:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 /* Body with sidebar layout */
@@ -133,144 +146,92 @@
   overflow: hidden;
 }
 
-/* Sidebar navigation */
+/* --- Sidebar navigation ---------------------------------------------------
+   A translucent rail ON the glass sheet, not an opaque block bolted to it.
+
+   The per-position icon colours that used to live here were removed: they were
+   hardcoded Tailwind hues (#8b5cf6 purple, #10b981 green, #ec4899 pink,
+   #06b6d4 cyan) with drop-shadow glows, which is neither the warm-paper/navy
+   brand nor a system anything else in the app uses. They were also keyed to
+   `nth-child` positions for a tab list that no longer exists — the comments
+   named Documents / Collaboration / Storage / Shape Libraries, none of which
+   are tabs any more (JP-218 moved them out), so the colours had silently
+   shifted onto the wrong entries. Icons now take the same treatment as a tile's
+   icon chip, and the accent marks the active tab.
+   ------------------------------------------------------------------------- */
 .settings-modal-sidebar {
   width: 210px;
-  background: var(--bg-secondary);
-  border-right: 1px solid var(--border-color);
-  padding: 16px 10px;
+  background: transparent;
+  border-right: 1px solid var(--glass-tile-border);
+  padding: var(--space-4) var(--space-2);
   flex-shrink: 0;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .settings-tab-btn {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   width: 100%;
-  padding: 12px 14px;
-  border: none;
-  border-radius: 10px;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid transparent;
+  border-radius: var(--radius-lg);
   background: transparent;
   color: var(--text-secondary);
-  font-size: 14px;
-  font-weight: 500;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
   text-align: left;
   cursor: pointer;
-  transition: all 0.15s ease;
-  position: relative;
-}
-
-.settings-tab-btn::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%) scaleY(0);
-  width: 3px;
-  height: 60%;
-  border-radius: 0 3px 3px 0;
-  background: var(--color-primary);
-  transition: transform 0.2s ease;
+  transition:
+    background-color var(--dur-med) var(--ease-out),
+    color var(--dur-med) var(--ease-out),
+    border-color var(--dur-med) var(--ease-out);
 }
 
 .settings-tab-btn:hover {
-  background: var(--bg-hover);
+  background: var(--glass-tile);
   color: var(--text-primary);
 }
 
+.settings-tab-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .settings-tab-btn.active {
-  background: linear-gradient(135deg, rgba(31, 51, 84, 0.12) 0%, rgba(31, 51, 84, 0.06) 100%);
+  background: var(--color-primary-light);
+  border-color: var(--color-primary-alpha);
   color: var(--color-primary);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
-.settings-tab-btn.active::before {
-  transform: translateY(-50%) scaleY(1);
-}
-
+/* The icon chip, borrowed from the tile anatomy so the rail and the mosaic
+   read as one system. */
 .settings-tab-icon {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 6px;
-  transition: all 0.2s ease;
+  width: 28px;
+  height: 28px;
+  flex: none;
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color-light);
+  box-shadow: var(--shadow-sm);
+  transition:
+    background var(--dur-med) var(--ease-out),
+    color var(--dur-med) var(--ease-out),
+    border-color var(--dur-med) var(--ease-out);
 }
 
-/* Icon colors and glow effects by tab position */
-/* Documents - Blue glow */
-.settings-tab-btn:nth-child(1) .settings-tab-icon {
-  color: var(--color-primary);
-  filter: drop-shadow(0 0 8px rgba(31, 51, 84, 0.4));
-}
-
-.settings-tab-btn:nth-child(1).active .settings-tab-icon {
-  filter: drop-shadow(0 0 12px rgba(31, 51, 84, 0.6));
-}
-
-/* General - Purple glow */
-.settings-tab-btn:nth-child(2) .settings-tab-icon {
-  color: #8b5cf6;
-  filter: drop-shadow(0 0 8px rgba(139, 92, 246, 0.4));
-}
-
-.settings-tab-btn:nth-child(2).active .settings-tab-icon {
-  filter: drop-shadow(0 0 12px rgba(139, 92, 246, 0.6));
-}
-
-/* Collaboration - Green glow */
-.settings-tab-btn:nth-child(3) .settings-tab-icon {
-  color: #10b981;
-  filter: drop-shadow(0 0 8px rgba(16, 185, 129, 0.4));
-}
-
-.settings-tab-btn:nth-child(3).active .settings-tab-icon {
-  filter: drop-shadow(0 0 12px rgba(16, 185, 129, 0.6));
-}
-
-/* Storage - Orange glow */
-.settings-tab-btn:nth-child(4) .settings-tab-icon {
-  color: var(--warning);
-  filter: drop-shadow(0 0 8px rgba(245, 158, 11, 0.4));
-}
-
-.settings-tab-btn:nth-child(4).active .settings-tab-icon {
-  filter: drop-shadow(0 0 12px rgba(245, 158, 11, 0.6));
-}
-
-/* Backup - Red glow */
-.settings-tab-btn:nth-child(5) .settings-tab-icon {
-  color: var(--danger-text);
-  filter: drop-shadow(0 0 8px rgba(239, 68, 68, 0.4));
-}
-
-.settings-tab-btn:nth-child(5).active .settings-tab-icon {
-  filter: drop-shadow(0 0 12px rgba(239, 68, 68, 0.6));
-}
-
-/* Style Profiles - Pink glow */
-.settings-tab-btn:nth-child(6) .settings-tab-icon {
-  color: #ec4899;
-  filter: drop-shadow(0 0 8px rgba(236, 72, 153, 0.4));
-}
-
-.settings-tab-btn:nth-child(6).active .settings-tab-icon {
-  filter: drop-shadow(0 0 12px rgba(236, 72, 153, 0.6));
-}
-
-/* Shape Libraries - Cyan glow */
-.settings-tab-btn:nth-child(7) .settings-tab-icon {
-  color: #06b6d4;
-  filter: drop-shadow(0 0 8px rgba(6, 182, 212, 0.4));
-}
-
-.settings-tab-btn:nth-child(7).active .settings-tab-icon {
-  filter: drop-shadow(0 0 12px rgba(6, 182, 212, 0.6));
+.settings-tab-btn.active .settings-tab-icon {
+  background: var(--grad-primary);
+  color: var(--color-on-primary);
+  border-color: transparent;
 }
 
 .settings-tab-label {
@@ -278,12 +239,27 @@
 }
 
 /* Content area */
+/* Full-bleed surface, readable column. A mosaic stretched across a 27" monitor
+   is not more scannable, just wider.
+
+   `width: 100%` is load-bearing, not belt-and-braces: the content area is a
+   flex COLUMN, and an auto inline margin on a flex item disables cross-axis
+   stretch. Without a definite width the item falls back to content-based
+   sizing — and a child carrying `container-type: inline-size` contributes
+   nothing to intrinsic size, so the whole panel collapsed to 0px wide. */
+.settings-modal-content > * {
+  width: 100%;
+  max-width: 1180px;
+  margin-inline: auto;
+}
+
 .settings-modal-content {
   flex: 1;
   min-width: 0;
   overflow: auto;
   padding: 24px;
-  background: var(--bg-primary);
+  /* Transparent: the glass sheet is the surface. */
+  background: transparent;
   /* Flex column so a tab that opts into `flex: 1` (e.g. the document
      browser) can fill the available height — including in fullscreen.
      Natural-height tabs still scroll normally. */
@@ -516,15 +492,9 @@
   background: rgba(0, 0, 0, 0.7);
 }
 
-[data-theme="dark"] .settings-modal {
-  background: var(--bg-primary);
-  box-shadow: var(--shadow-xl), 0 0 0 1px var(--border-color);
-}
-
-[data-theme="dark"] .settings-modal-header {
-  background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
-  border-color: var(--border-color);
-}
+/* The glass + wash tokens already flip per theme, so the sheet needs no dark
+   override. It previously had one using the `background` SHORTHAND, which would
+   silently reset `background-image` and erase the wash in dark mode. */
 
 [data-theme="dark"] .settings-modal-header h2 {
   color: var(--text-primary);
@@ -539,32 +509,15 @@
   color: var(--danger-text);
 }
 
-[data-theme="dark"] .settings-modal-sidebar {
-  background: var(--bg-secondary);
-  border-color: var(--border-color);
-}
+/* The sidebar and tab rules above are token-based and already correct in both
+   themes, so the dark overrides that used to sit here are gone. They set an
+   opaque `--bg-secondary` rail and hardcoded rgba hover/active fills, all of
+   which fought the glass sheet.
 
-[data-theme="dark"] .settings-tab-btn {
-  color: var(--text-secondary);
-}
-
-[data-theme="dark"] .settings-tab-btn:hover {
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--text-primary);
-}
-
-[data-theme="dark"] .settings-tab-btn.active {
-  background: linear-gradient(135deg, rgba(224, 198, 144, 0.15) 0%, rgba(224, 198, 144, 0.08) 100%);
-  color: var(--color-primary);
-}
-
-[data-theme="dark"] .settings-tab-btn.active::before {
-  background: var(--color-primary);
-}
-
-[data-theme="dark"] .settings-modal-content {
-  background: var(--bg-primary);
-}
+   One of them was also actively broken: a `[data-theme="dark"]
+   .settings-modal-content { background: var(--bg-primary) }` rule had lost its
+   prefix during editing and was painting an opaque fill over the glass in BOTH
+   themes. The content area is transparent — see the rule above. */
 
 [data-theme="dark"] .settings-modal-content::-webkit-scrollbar-thumb {
   background: var(--border-color);

--- a/src/ui/SettingsModal.tsx
+++ b/src/ui/SettingsModal.tsx
@@ -11,15 +11,7 @@
  */
 
 import { useState, useCallback, useEffect } from 'react';
-import {
-  Settings,
-  Package,
-  Palette,
-  SwatchBook,
-  Info,
-  Maximize2,
-  Minimize2,
-} from 'lucide-react';
+import { Settings, Package, Palette, SwatchBook, Info } from 'lucide-react';
 import { GeneralSettings } from './settings/GeneralSettings';
 import { StyleProfileSettings } from './settings/StyleProfileSettings';
 import { BackupSettings } from './settings/BackupSettings';
@@ -62,8 +54,6 @@ export interface SettingsModalProps {
 
 export function SettingsModal({ isOpen, onClose, initialTab = 'general' }: SettingsModalProps) {
   const [activeTab, setActiveTab] = useState<SettingsTab>(initialTab);
-  const [isFullscreen, setIsFullscreen] = useState(false);
-  const toggleFullscreen = useCallback(() => setIsFullscreen((v) => !v), []);
 
   // Reset to initial tab when modal opens
   useEffect(() => {
@@ -99,24 +89,16 @@ export function SettingsModal({ isOpen, onClose, initialTab = 'general' }: Setti
 
   return (
     <div className="settings-modal-overlay" onClick={handleOverlayClick}>
-      <div
-        className={`settings-modal${isFullscreen ? ' is-fullscreen' : ''}`}
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="settings-modal" onClick={(e) => e.stopPropagation()}>
         {/* Header */}
         <div className="settings-modal-header">
           <h2>Settings</h2>
           <div className="settings-modal-header-actions">
-            <button
-              className="settings-modal-fullscreen"
-              onClick={toggleFullscreen}
-              aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
-              title={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
-            >
-              {isFullscreen ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
-            </button>
-            <button className="settings-modal-close" onClick={onClose} aria-label="Close">
-              ×
+            <button className="settings-modal-close" onClick={onClose} aria-label="Close settings">
+              <span className="settings-modal-close__glyph" aria-hidden="true">
+                ×
+              </span>
+              Close
             </button>
           </div>
         </div>

--- a/src/ui/appearance/applyAppearance.ts
+++ b/src/ui/appearance/applyAppearance.ts
@@ -11,6 +11,7 @@
  *   set for overridden tokens, removed otherwise — so a Light customization can
  *   never bleed onto Dark, and clearing a slot reverts cleanly to the base.
  * Density → `data-density` root attribute.
+ * Glass → `data-glass` root attribute (the glass token block's on/off switch).
  * UI size → `--ui-scale` root var (rem root font-size).
  * Motion → handed to `adaptiveBudget`, the sole authority over `data-reduced-motion`.
  *
@@ -57,6 +58,11 @@ function applyNonColor(prefs: AppearancePrefs): void {
     // Rounded prose tables (opt-out). The table CSS keys off this attribute;
     // only the "false" (squared) case needs an override (JP-416).
     root.dataset['roundedTables'] = String(prefs.roundedTables);
+    // Glass chrome (opt-out). `[data-glass="off"]` in index.css resolves every
+    // --glass-*/--shadow-float/--grad-* token back to the opaque surface values,
+    // so the whole treatment is one attribute — no per-component branching and
+    // no second code path to keep in sync (JP-253).
+    root.dataset['glass'] = prefs.glass ? 'on' : 'off';
   }
   setMotionPreference(prefs.motion);
 }

--- a/src/ui/floatingPosition.test.ts
+++ b/src/ui/floatingPosition.test.ts
@@ -4,6 +4,7 @@ import {
   clampPanelBounds,
   resolveIndicatorPosition,
   resolveViewerPanelBounds,
+  resolveMenuPlacement,
   MIN_PANEL_SIZE,
   VIEWPORT_MARGIN,
   DEFAULT_TOP,
@@ -119,5 +120,102 @@ describe('resolveViewerPanelBounds', () => {
   it('respects stored in-range bounds', () => {
     const stored = { x: 100, y: 120, w: 480, h: 560 };
     expect(resolveViewerPanelBounds(stored, VIEWPORT)).toEqual(stored);
+  });
+});
+
+describe('resolveMenuPlacement (anchored menu / popover)', () => {
+  // A toolbar chip near the right edge of a roomy window.
+  const TRIGGER = { top: 8, bottom: 40, right: 1044 };
+  const ROOMY = { w: 1280, h: 860 };
+  const base = {
+    trigger: TRIGGER,
+    viewport: ROOMY,
+    preferredWidth: 340,
+    narrow: false,
+    contentHeight: 560,
+  };
+
+  it('opens below the trigger, right-aligned to it', () => {
+    const out = resolveMenuPlacement(base);
+    expect(out.flipped).toBe(false);
+    expect(out.top).toBe(TRIGGER.bottom + 6);
+    expect(out.left + out.width).toBe(TRIGGER.right);
+    expect(out.width).toBe(340);
+  });
+
+  it('keeps its full width on a roomy viewport', () => {
+    expect(resolveMenuPlacement(base).width).toBe(340);
+  });
+
+  it('shrinks to fit rather than running off a narrow viewport', () => {
+    // The reported bug: a 340px panel on a 320px window used to overflow,
+    // because the compact variant was gated on a coarse pointer.
+    const viewport = { w: 320, h: 640 };
+    const out = resolveMenuPlacement({
+      ...base,
+      viewport,
+      narrow: true,
+      trigger: { top: 8, bottom: 40, right: 300 },
+    });
+    expect(out.width).toBe(320 - VIEWPORT_MARGIN * 2);
+    expect(out.left).toBeGreaterThanOrEqual(VIEWPORT_MARGIN);
+    expect(out.left + out.width).toBeLessThanOrEqual(viewport.w - VIEWPORT_MARGIN);
+  });
+
+  it('never pushes off the left edge when the trigger sits near it', () => {
+    const out = resolveMenuPlacement({
+      ...base,
+      trigger: { top: 8, bottom: 40, right: 120 },
+    });
+    expect(out.left).toBeGreaterThanOrEqual(VIEWPORT_MARGIN);
+  });
+
+  it('caps its height on a short viewport so it scrolls instead of truncating', () => {
+    const viewport = { w: 1100, h: 400 };
+    const out = resolveMenuPlacement({ ...base, viewport });
+    expect(out.maxHeight).toBeLessThan(base.contentHeight);
+    expect(out.top + out.maxHeight).toBeLessThanOrEqual(viewport.h);
+  });
+
+  it('flips above the trigger when below is cramped and above is roomier', () => {
+    // A trigger low in the window: 60px underneath, ~700 above.
+    const out = resolveMenuPlacement({
+      ...base,
+      viewport: { w: 1280, h: 860 },
+      trigger: { top: 760, bottom: 790, right: 1044 },
+    });
+    expect(out.flipped).toBe(true);
+    expect(out.top + Math.min(base.contentHeight, out.maxHeight)).toBeLessThanOrEqual(790);
+  });
+
+  it('does not flip when below is cramped but above is worse', () => {
+    // Trigger near the top of a short window: little room either way, but more
+    // below than above — flipping would make it worse, not better.
+    const out = resolveMenuPlacement({
+      ...base,
+      viewport: { w: 1280, h: 300 },
+      trigger: { top: 8, bottom: 40, right: 1044 },
+    });
+    expect(out.flipped).toBe(false);
+  });
+
+  it('stays on screen in every combination of the above', () => {
+    for (const viewport of [{ w: 320, h: 480 }, { w: 768, h: 400 }, { w: 1280, h: 860 }]) {
+      for (const trigger of [
+        { top: 8, bottom: 40, right: 100 },
+        { top: 8, bottom: 40, right: viewport.w - 8 },
+        { top: viewport.h - 60, bottom: viewport.h - 28, right: viewport.w - 8 },
+      ]) {
+        const out = resolveMenuPlacement({
+          ...base,
+          viewport,
+          trigger,
+          narrow: viewport.w < 640,
+        });
+        expect(out.left).toBeGreaterThanOrEqual(VIEWPORT_MARGIN);
+        expect(out.left + out.width).toBeLessThanOrEqual(viewport.w - VIEWPORT_MARGIN + 1);
+        expect(out.top).toBeGreaterThanOrEqual(0);
+      }
+    }
   });
 });

--- a/src/ui/floatingPosition.ts
+++ b/src/ui/floatingPosition.ts
@@ -96,6 +96,86 @@ export function resolveViewerPanelBounds(
   );
 }
 
+// ---------------------------------------------------------------------------
+// Anchored menu / popover placement (JP-253)
+// ---------------------------------------------------------------------------
+
+/** The parts of a trigger's rect that placement actually depends on. */
+export interface TriggerRect {
+  top: number;
+  bottom: number;
+  right: number;
+}
+
+export interface MenuPlacementInput {
+  trigger: TriggerRect;
+  viewport: Viewport;
+  /** Width the menu wants when there is room for it. */
+  preferredWidth: number;
+  /** Narrow viewport band — shrink to fit rather than keeping the full width. */
+  narrow: boolean;
+  /** The menu's natural (unconstrained) height. */
+  contentHeight: number;
+  /** Space between trigger and menu. */
+  gap?: number;
+  /** Below this much room underneath, opening downward is not worth it. */
+  minDropHeight?: number;
+  margin?: number;
+}
+
+export interface MenuPlacement {
+  left: number;
+  top: number;
+  width: number;
+  /** Cap for the menu's height — the menu scrolls past it, never truncates. */
+  maxHeight: number;
+  /** Opened above the trigger instead of below. */
+  flipped: boolean;
+}
+
+/**
+ * Place a menu anchored under (or over) a trigger, right-aligned to it, fully
+ * inside the viewport.
+ *
+ * Pure, so the behaviour that matters — a narrow viewport shrinks the menu, a
+ * short one caps and scrolls it, and neither can push it off-screen — is
+ * unit-tested without a DOM. This is the logic behind the layout menu's
+ * overflow fix; a hand-rolled `position: absolute; right: 0` had none of it.
+ */
+export function resolveMenuPlacement({
+  trigger,
+  viewport,
+  preferredWidth,
+  narrow,
+  contentHeight,
+  gap = 6,
+  minDropHeight = 260,
+  margin = VIEWPORT_MARGIN,
+}: MenuPlacementInput): MenuPlacement {
+  const width = narrow
+    ? Math.min(preferredWidth, Math.max(0, viewport.w - margin * 2))
+    : preferredWidth;
+
+  const below = viewport.h - trigger.bottom - gap - margin;
+  const above = trigger.top - gap - margin;
+  // Flip only when downward is genuinely cramped AND upward is roomier —
+  // otherwise a menu near the bottom would flip for no gain.
+  const flipped = below < minDropHeight && above > below;
+
+  const maxHeight = Math.max(160, flipped ? above : below);
+  const height = Math.min(contentHeight, maxHeight);
+  const top = flipped ? trigger.top - gap - height : trigger.bottom + gap;
+
+  const clamped = clampToViewport(
+    { x: trigger.right - width, y: top },
+    { w: width, h: height },
+    viewport,
+    margin
+  );
+
+  return { left: clamped.x, top: clamped.y, width, maxHeight, flipped };
+}
+
 /**
  * Resolve the effective top-left for the indicator. A `null` stored position
  * falls back to the top-right anchor; a stored position is clamped into the

--- a/src/ui/layout/LayoutSelector.css
+++ b/src/ui/layout/LayoutSelector.css
@@ -1,4 +1,4 @@
-/* LayoutSelector — toolbar chip + popover dropdown. */
+/* LayoutSelector — toolbar chip + portalled tile popover (JP-253). */
 
 .layout-selector-wrapper {
   position: relative;
@@ -22,154 +22,123 @@
   white-space: nowrap;
 }
 
-.layout-selector-dropdown {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  width: 320px;
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-lg);
-  z-index: 1000;
-  padding: var(--space-1-5);
-}
+/* --- The popover ----------------------------------------------------------
+   Portalled to <body>, so `fixed` + viewport coordinates from the placement
+   effect in LayoutSelector.tsx. `left`/`top`/`width`/`max-height` are all set
+   inline there; this rule owns appearance only.
 
-.layout-selector-list {
+   `container-type: inline-size` is what makes the tile container queries in
+   tiles.css resolve against the popover's width rather than the viewport —
+   without it a 340px popover would style itself as though it had the whole
+   window, and the tiles would never reflow.
+   ------------------------------------------------------------------------- */
+.layout-selector-dropdown {
+  position: fixed;
+  z-index: 10100;
+  container-type: inline-size;
   display: flex;
   flex-direction: column;
-  gap: var(--space-0-5);
+  gap: var(--space-3);
+  padding: var(--space-2);
+  background: var(--glass-surface);
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-float), var(--glass-highlight);
+  /* A too-tall panel scrolls; it never truncates. Paired with the max-height
+     the placement effect computes from the room actually available. */
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
-.layout-selector-option {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: var(--space-2) var(--space-2);
-  border: none;
-  background: transparent;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  text-align: left;
-  color: var(--text-primary);
+/* --- Layout preset tile ---------------------------------------------------
+   The one specialization the tile system doesn't cover: thumbnail-led rather
+   than icon-led, because a layout is a shape and a 30px chip cannot show one.
+   Everything else — surface, hover, focus, radius — is inherited from `.tile`.
+   ------------------------------------------------------------------------- */
+.tile--layout {
+  gap: var(--space-2);
+  justify-content: flex-start;
+}
+
+.layout-tile__thumb {
+  display: block;
   width: 100%;
 }
 
-.layout-selector-option:hover,
-.layout-selector-option:focus-visible {
-  background: var(--bg-secondary);
-  outline: none;
+/* Scales with the tile, but capped: at a single-column width the tile is ~270px
+   and an uncapped thumbnail grows to 164px tall, swamping the name it labels. */
+.layout-tile__thumb svg {
+  width: 100%;
+  max-width: 140px;
+  height: auto;
 }
 
-.layout-selector-option.active {
-  background: var(--bg-secondary);
-}
-
-.layout-selector-option-text {
-  flex: 1 1 auto;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-0-5);
-  min-width: 0;
-}
-
-.layout-selector-option-title {
+.layout-tile__row {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
   gap: var(--space-2);
-}
-
-.layout-selector-option-shortcut {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-normal);
-  color: var(--text-secondary);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-
-.layout-selector-option-desc {
-  font-size: var(--font-size-xs);
-  color: var(--text-secondary);
-  line-height: var(--line-height-snug);
-}
-
-/* Section labels — the popover carries two unrelated groups (presets and
-   panel visibility) and needs to say which is which. */
-.layout-selector-section-label {
-  padding: var(--space-1) var(--space-2) var(--space-0-5);
-  font-size: var(--font-size-2xs);
-  font-weight: var(--font-weight-semibold);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
-}
-
-.layout-selector-panels {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-0-5);
-  margin-top: var(--space-1);
-  padding-top: var(--space-1);
-  border-top: 1px solid var(--border-color);
-}
-
-.layout-selector-panel-item {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  width: 100%;
-  padding: 6px var(--space-2);
-  border: none;
-  border-radius: var(--radius-md);
-  background: transparent;
-  color: var(--text-primary);
-  font-size: var(--font-size-sm);
-  text-align: left;
-  cursor: pointer;
-}
-
-.layout-selector-panel-item:hover:not(:disabled),
-.layout-selector-panel-item:focus-visible:not(:disabled) {
-  background: var(--bg-secondary);
-  outline: none;
-}
-
-.layout-selector-panel-item:disabled {
-  color: var(--text-muted);
-  cursor: default;
-}
-
-/* Fixed box so the labels form a column whether or not a row is checked. */
-.layout-selector-panel-check {
-  flex: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 14px;
-  height: 14px;
-  color: var(--color-primary);
-}
-
-.layout-selector-panel-label {
-  flex: 1 1 auto;
   min-width: 0;
 }
 
-.layout-selector-panel-note {
+.layout-tile__name {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.2;
+}
+
+.layout-tile__key {
   flex: none;
   font-size: var(--font-size-2xs);
   color: var(--text-muted);
+  font-family: var(--font-mono);
 }
 
+.layout-tile__desc {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  line-height: var(--line-height-snug);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* "Which layout am I on" is this popover's whole job, so the active tile gets a
+   solid accent border and a check badge — a background tint alone is too quiet
+   to answer it at a glance. */
+.tile--layout[aria-checked='true'] {
+  background: var(--color-primary-light);
+  border-color: var(--color-primary);
+}
+
+.tile--layout[aria-checked='true']::after {
+  content: '✓';
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  z-index: 1;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  font-size: 10px;
+  line-height: 1;
+}
+
+/* --- Footer --------------------------------------------------------------- */
 .layout-selector-footer {
   display: flex;
   flex-direction: column;
   gap: var(--space-0-5);
-  margin-top: var(--space-1);
-  padding-top: var(--space-1-5);
-  border-top: 1px solid var(--border-color);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--border-color-light);
 }
 
 .layout-selector-footer-item {
@@ -179,7 +148,7 @@
   padding: 7px 10px;
   border: none;
   background: transparent;
-  color: var(--text-primary);
+  color: var(--text-secondary);
   font-size: var(--font-size-sm);
   text-align: left;
   cursor: pointer;
@@ -189,15 +158,7 @@
 
 .layout-selector-footer-item:hover,
 .layout-selector-footer-item:focus-visible {
-  background: var(--bg-secondary);
+  background: var(--bg-hover);
+  color: var(--text-primary);
   outline: none;
-}
-
-.layout-selector-toggle {
-  cursor: pointer;
-}
-
-.layout-selector-toggle input[type='checkbox'] {
-  margin: 0;
-  cursor: pointer;
 }

--- a/src/ui/layout/LayoutSelector.tsx
+++ b/src/ui/layout/LayoutSelector.tsx
@@ -19,16 +19,38 @@
  * The popover opens on hover as well as click (same delayed-close pattern as
  * the page tab strip's overflow menu), so scanning the view controls costs no
  * clicks; the delay is what keeps a diagonal pointer path from dismissing it.
+ *
+ * ## Positioning (JP-253)
+ *
+ * The panel is **portalled to the body and measured against the viewport**. It
+ * used to be `position: absolute; right: 0` at a fixed 320px inside the toolbar,
+ * with no clamp and no max-height, so a narrow window pushed it off-screen and a
+ * short one truncated it. The compact variant that would have saved it was gated
+ * on `mobileActive`, which requires a **coarse pointer** — so a narrowed desktop
+ * window never qualified.
+ *
+ * Sizing therefore keys off `useBreakpoint().band` (viewport width), not the
+ * touch signal; the coarse-pointer signal governs hit-target size only. This is
+ * the same split settled in JP-486.
+ *
+ * `ToolbarDropdown` is deliberately not reused here: it clamps horizontally but
+ * never vertically, and owns its own trigger markup and click semantics, which
+ * would mean fighting it for hover-open and the menu ARIA roles below. The
+ * tested pure clamp from `floatingPosition.ts` is reused instead.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Check, PanelsTopLeft } from 'lucide-react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { PanelsTopLeft, Settings2, SlidersHorizontal, Layers, Compass, FileText } from 'lucide-react';
 import { Icon } from '../icons';
 import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
 import { LAYOUT_DESCRIPTIONS, LAYOUT_LABELS, propertiesDockedVisible, resolvePanelState } from './modes';
 import { useActiveLayoutMode, useLayoutActions } from './useLayout';
+import { useBreakpoint } from './useBreakpoint';
 import { LAYOUT_MODES, PANEL_IDS, type LayoutMode, type PanelId } from './types';
 import { LayoutThumbnail } from './LayoutThumbnail';
+import { TileGroup, ToggleTile } from '../tiles/Tile';
+import { resolveMenuPlacement, type MenuPlacement } from '../floatingPosition';
 import './LayoutSelector.css';
 
 /** Panel names as the user meets them elsewhere (Settings → Layout, the
@@ -40,9 +62,24 @@ const PANEL_LABELS: Record<PanelId, string> = {
   navigator: 'Navigator',
 };
 
+/** One glyph per panel, so the panel tiles are icon-first like every other tile. */
+const PANEL_ICONS = {
+  document: FileText,
+  properties: SlidersHorizontal,
+  layers: Layers,
+  navigator: Compass,
+} as const;
+
 /** Matches the tab strip's overflow menu — long enough to cross the gap
  *  between the chip and the panel without the menu evaporating. */
 const CLOSE_DELAY_MS = 200;
+
+/** Panel width at a regular viewport. */
+const PANEL_WIDTH = 340;
+
+/** Below this much room, opening downward would leave an unusably short panel,
+ *  so it flips above the trigger instead. */
+const MIN_DROP_HEIGHT = 260;
 
 export interface LayoutSelectorProps {
   /** Called when the user clicks "Customize layout…" — wires to Settings. */
@@ -55,9 +92,13 @@ export function LayoutSelector({ onOpenLayoutSettings, compact = false }: Layout
   const activeMode = useActiveLayoutMode();
   const { setActiveLayout, togglePanelVisible } = useLayoutActions();
   const overrides = useUIPreferencesStore((s) => s.layout.modeOverrides[activeMode]);
+  const { band } = useBreakpoint();
 
   const [isOpen, setIsOpen] = useState(false);
+  const [position, setPosition] = useState<MenuPlacement | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const cancelClose = useCallback(() => {
@@ -84,22 +125,70 @@ export function LayoutSelector({ onOpenLayoutSettings, compact = false }: Layout
 
   useEffect(() => () => cancelClose(), [cancelClose]);
 
+  /**
+   * Place the panel against the viewport. Width shrinks on a narrow viewport;
+   * the panel opens downward unless there isn't room, in which case it flips
+   * above the trigger. `maxHeight` is what turns a too-tall panel into a
+   * scrolling one instead of a truncated one.
+   */
+  const place = useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+
+    const rect = trigger.getBoundingClientRect();
+    const viewport = { w: window.innerWidth, h: window.innerHeight };
+
+    // All the arithmetic lives in `resolveMenuPlacement` — pure, and unit-tested
+    // in floatingPosition.test.ts, so the overflow fix is verified in CI rather
+    // than only by resizing a window.
+    setPosition(
+      resolveMenuPlacement({
+        trigger: { top: rect.top, bottom: rect.bottom, right: rect.right },
+        viewport,
+        preferredWidth: PANEL_WIDTH,
+        narrow: band === 'narrow',
+        contentHeight: panelRef.current?.scrollHeight ?? Number.POSITIVE_INFINITY,
+        minDropHeight: MIN_DROP_HEIGHT,
+      })
+    );
+  }, [band]);
+
+  // Place before paint so the panel never renders at the wrong spot first.
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setPosition(null);
+      return;
+    }
+    place();
+  }, [isOpen, place]);
+
   useEffect(() => {
     if (!isOpen) return;
     const onClickOutside = (e: PointerEvent) => {
       const target = e.target as Node | null;
-      if (target && !wrapperRef.current?.contains(target)) close();
+      if (!target) return;
+      if (wrapperRef.current?.contains(target)) return;
+      // The panel is portalled out of the wrapper, so it needs its own check.
+      if (panelRef.current?.contains(target)) return;
+      close();
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') close();
     };
+    const onReflow = () => place();
+
     window.addEventListener('pointerdown', onClickOutside);
     window.addEventListener('keydown', onKey);
+    window.addEventListener('resize', onReflow);
+    // Capture phase: the toolbar or a panel can scroll without the window doing so.
+    window.addEventListener('scroll', onReflow, true);
     return () => {
       window.removeEventListener('pointerdown', onClickOutside);
       window.removeEventListener('keydown', onKey);
+      window.removeEventListener('resize', onReflow);
+      window.removeEventListener('scroll', onReflow, true);
     };
-  }, [isOpen, close]);
+  }, [isOpen, close, place]);
 
   const handlePick = (mode: LayoutMode) => {
     setActiveLayout(mode);
@@ -130,6 +219,84 @@ export function LayoutSelector({ onOpenLayoutSettings, compact = false }: Layout
     [activeMode, overrides],
   );
 
+  const panel = (
+    <div
+      ref={panelRef}
+      className="layout-selector-dropdown"
+      role="menu"
+      aria-label="View"
+      style={
+        position
+          ? {
+              left: position.left,
+              top: position.top,
+              width: position.width,
+              maxHeight: position.maxHeight,
+            }
+          : // Pre-measurement: keep it out of sight rather than flashing at 0,0.
+            { visibility: 'hidden', left: 0, top: 0, width: PANEL_WIDTH }
+      }
+      onMouseEnter={open}
+      onMouseLeave={scheduleClose}
+    >
+      <TileGroup title="Layout" icon={PanelsTopLeft} min={132} row={0}>
+        {LAYOUT_MODES.map((mode, idx) => (
+          <button
+            key={mode}
+            type="button"
+            role="menuitemradio"
+            aria-checked={mode === activeMode}
+            // The visible text lives in nested spans alongside an aria-hidden
+            // thumbnail, which would otherwise leave these options nameless.
+            aria-label={`${LAYOUT_LABELS[mode]} layout — ${LAYOUT_DESCRIPTIONS[mode]}`}
+            className="tile tile--layout"
+            onClick={() => handlePick(mode)}
+          >
+            <span className="layout-tile__thumb" aria-hidden="true">
+              <LayoutThumbnail mode={mode} active={mode === activeMode} width={56} height={34} />
+            </span>
+            <span className="layout-tile__row">
+              <span className="layout-tile__name">{LAYOUT_LABELS[mode]}</span>
+              <span className="layout-tile__key">⌘⇧{idx + 1}</span>
+            </span>
+            <span className="layout-tile__desc">{LAYOUT_DESCRIPTIONS[mode]}</span>
+          </button>
+        ))}
+      </TileGroup>
+
+      <TileGroup title="Panels" icon={Settings2} min={132} row={0}>
+        {panels.map(({ id, visible, layoutOwned }) => (
+          <ToggleTile
+            key={id}
+            compact
+            icon={PANEL_ICONS[id]}
+            label={PANEL_LABELS[id]}
+            checked={visible}
+            disabled={layoutOwned}
+            onLabel="Shown"
+            offLabel="Hidden"
+            {...(layoutOwned ? { note: 'on selection' } : {})}
+            // The popover stays open: showing a panel is the kind of thing you
+            // do two or three of in a row.
+            onCheckedChange={() => togglePanelVisible(id)}
+            title={
+              layoutOwned
+                ? 'Relaxed shows Properties only while something is selected'
+                : `${visible ? 'Hide' : 'Show'} the ${PANEL_LABELS[id]} panel`
+            }
+          />
+        ))}
+      </TileGroup>
+
+      <div className="layout-selector-footer">
+        <button type="button" className="layout-selector-footer-item" onClick={handleCustomize}>
+          <Icon icon={Settings2} size={15} />
+          Customize layout…
+        </button>
+      </div>
+    </div>
+  );
+
   return (
     <div
       className="layout-selector-wrapper"
@@ -138,6 +305,7 @@ export function LayoutSelector({ onOpenLayoutSettings, compact = false }: Layout
       onMouseLeave={scheduleClose}
     >
       <button
+        ref={triggerRef}
         type="button"
         className={`toolbar-menu-chip layout-selector-chip ${compact ? 'compact' : ''} ${isOpen ? 'open' : ''}`}
         onClick={() => (isOpen ? close() : open())}
@@ -157,76 +325,7 @@ export function LayoutSelector({ onOpenLayoutSettings, compact = false }: Layout
         )}
       </button>
 
-      {isOpen && (
-        <div className="layout-selector-dropdown" role="menu" aria-label="View">
-          <div className="layout-selector-section-label">Layout</div>
-          <div className="layout-selector-list">
-            {LAYOUT_MODES.map((mode, idx) => (
-              <button
-                key={mode}
-                type="button"
-                role="menuitemradio"
-                aria-checked={mode === activeMode}
-                // The visible text lives in nested divs alongside an
-                // aria-hidden thumbnail, which left these options nameless.
-                aria-label={`${LAYOUT_LABELS[mode]} layout — ${LAYOUT_DESCRIPTIONS[mode]}`}
-                className={`layout-selector-option ${mode === activeMode ? 'active' : ''}`}
-                onClick={() => handlePick(mode)}
-              >
-                <LayoutThumbnail mode={mode} active={mode === activeMode} />
-                <div className="layout-selector-option-text">
-                  <div className="layout-selector-option-title">
-                    {LAYOUT_LABELS[mode]}
-                    <span className="layout-selector-option-shortcut">⌘⇧{idx + 1}</span>
-                  </div>
-                  <div className="layout-selector-option-desc">{LAYOUT_DESCRIPTIONS[mode]}</div>
-                </div>
-              </button>
-            ))}
-          </div>
-
-          <div className="layout-selector-panels">
-            <div className="layout-selector-section-label">Panels</div>
-            {panels.map(({ id, visible, layoutOwned }) => (
-              <button
-                key={id}
-                type="button"
-                role="menuitemcheckbox"
-                aria-checked={visible}
-                disabled={layoutOwned}
-                className="layout-selector-panel-item"
-                // A checkbox is named for the thing, not the action — the
-                // action is already carried by the role plus aria-checked.
-                aria-label={PANEL_LABELS[id]}
-                // The popover stays open: showing a panel is the kind of thing
-                // you do two or three of in a row.
-                onClick={() => togglePanelVisible(id)}
-                title={
-                  layoutOwned
-                    ? 'Relaxed shows Properties only while something is selected'
-                    : `${visible ? 'Hide' : 'Show'} the ${PANEL_LABELS[id]} panel`
-                }
-              >
-                <span className="layout-selector-panel-check" aria-hidden="true">
-                  {visible && <Icon icon={Check} size={13} />}
-                </span>
-                <span className="layout-selector-panel-label">{PANEL_LABELS[id]}</span>
-                {layoutOwned && <span className="layout-selector-panel-note">on selection</span>}
-              </button>
-            ))}
-          </div>
-
-          <div className="layout-selector-footer">
-            <button
-              type="button"
-              className="layout-selector-footer-item"
-              onClick={handleCustomize}
-            >
-              Customize layout…
-            </button>
-          </div>
-        </div>
-      )}
+      {isOpen && createPortal(panel, document.body)}
     </div>
   );
 }

--- a/src/ui/settings/AboutSettings.css
+++ b/src/ui/settings/AboutSettings.css
@@ -1,23 +1,16 @@
-/* About settings tab (JP-327). Two-column key/value list for build identity. */
-
-.about-list {
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: 6px 16px;
-  margin: 0;
+/* Settings → About. Build identity on the shared tile system (JP-253). */
+.about-settings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: 4px 0;
+  /* Query container for the tile container queries. */
+  container-type: inline-size;
 }
 
-.about-label {
-  color: var(--text-secondary, #6b7280);
-  font-size: 13px;
-}
-
-.about-value {
-  margin: 0;
-  font-size: 13px;
-  word-break: break-word;
-}
-
-.about-value-mono {
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+/* Versions and SHAs are strings you compare character by character. */
+.about-mono .tile__metric {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-base);
+  letter-spacing: 0;
 }

--- a/src/ui/settings/AboutSettings.tsx
+++ b/src/ui/settings/AboutSettings.tsx
@@ -9,7 +9,9 @@
  */
 
 import { useEffect, useState } from 'react';
+import { Clock, GitCommitHorizontal, Monitor, Package, Radio, Tag } from 'lucide-react';
 import { useConnectionStore } from '../../store/connectionStore';
+import { StatusTile, TileGroup } from '../tiles/Tile';
 import './AboutSettings.css';
 
 const PLATFORM = __IS_TAURI__ ? 'Desktop (Tauri)' : 'Web (PWA)';
@@ -66,40 +68,46 @@ export function AboutSettings() {
     <div className="about-settings">
       <h3 className="settings-section-title">About</h3>
 
-      <div className="settings-group">
-        <h4 className="settings-group-title">DocuShark</h4>
-        <dl className="about-list">
-          <AboutRow label="Version" value={__APP_VERSION__} mono />
-          <AboutRow label="Commit" value={__GIT_SHA__} mono />
-          <AboutRow label="Built" value={formatBuildTime(__BUILD_TIME__)} />
-          <AboutRow label="Platform" value={PLATFORM} />
-        </dl>
-      </div>
+      <TileGroup title="DocuShark" icon={Package}>
+        <StatusTile icon={Tag} label="Version" value={__APP_VERSION__} className="about-mono" />
+        <StatusTile
+          icon={GitCommitHorizontal}
+          label="Commit"
+          value={__GIT_SHA__}
+          className="about-mono"
+        />
+        <StatusTile icon={Clock} label="Built" value={formatBuildTime(__BUILD_TIME__)} />
+        <StatusTile icon={Monitor} label="Platform" value={PLATFORM} />
+      </TileGroup>
 
-      <div className="settings-group">
-        <h4 className="settings-group-title">Relay</h4>
+      <TileGroup title="Relay" icon={Radio}>
         {relay ? (
-          <dl className="about-list">
-            <AboutRow label="Version" value={relay.version} mono />
-            {relay.commit ? <AboutRow label="Commit" value={relay.commit} mono /> : null}
-            <AboutRow label="Status" value="Connected" />
-          </dl>
+          <>
+            <StatusTile icon={Tag} label="Version" value={relay.version} className="about-mono" />
+            {relay.commit ? (
+              <StatusTile
+                icon={GitCommitHorizontal}
+                label="Commit"
+                value={relay.commit}
+                className="about-mono"
+              />
+            ) : null}
+            <StatusTile icon={Radio} label="Status" value="Connected" />
+          </>
         ) : (
-          <p className="settings-hint">
-            {connected ? 'Relay version unavailable.' : 'Not connected to a relay.'}
-          </p>
+          <StatusTile
+            icon={Radio}
+            label="Status"
+            value={connected ? 'Unavailable' : 'Not connected'}
+            hint={
+              connected
+                ? 'Connected, but this relay did not report a version.'
+                : 'Connect to a workspace to see its relay build.'
+            }
+          />
         )}
-      </div>
+      </TileGroup>
     </div>
-  );
-}
-
-function AboutRow({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
-  return (
-    <>
-      <dt className="about-label">{label}</dt>
-      <dd className={`about-value${mono ? ' about-value-mono' : ''}`}>{value}</dd>
-    </>
   );
 }
 

--- a/src/ui/settings/AppearanceSettings.css
+++ b/src/ui/settings/AppearanceSettings.css
@@ -1,50 +1,52 @@
 /* Settings → Appearance.
  *
- * Reuses the shared `.settings-*` group/row/label/hint/slider classes defined
- * in GeneralSettings.css (co-loaded with the settings module graph). Only the
- * Appearance-specific additions live here. (The settings-menu rework — JP-211 —
- * is expected to consolidate these shared classes into one place.) */
+ * Built on the tile system (`../tiles/tiles.css`), which owns the mosaic, the
+ * tile chrome and the reflow. Only the Appearance-specific bits live here: the
+ * controls this panel hosts inside tiles (theme presets, prose backdrops) and
+ * the two surfaces that are sub-panels rather than controls. */
 
 .appearance-settings {
   display: flex;
   flex-direction: column;
+  gap: var(--space-5);
+  /* Establishes the query container for the tile container queries, so the
+     tiles reflow against the settings pane's width and not the window's. */
+  container-type: inline-size;
 }
 
-/* Switch row: label + thumb on one line, hint beneath (mirrors the checkbox
-   row pattern but for the Radix-based Switch). */
-.appearance-settings .settings-row-switch {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+/* --- Tiles that host an existing control ---------------------------------
+   `ColorField` and `LayoutSettings` render their own labels and internals, so
+   these tiles are containers: no head, no fixed row, content sets the height.
+   ------------------------------------------------------------------------- */
+.tile--field,
+.tile--embed {
+  justify-content: flex-start;
+  padding: var(--space-3);
 }
 
-.appearance-settings .settings-switch-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  cursor: pointer;
+.tile__body--only {
+  margin-top: 0;
+  width: 100%;
 }
 
-.appearance-settings .settings-switch-text {
-  font-size: 14px;
-  color: var(--text-primary);
+/* The embedded panel spans the full pane — it is a section, not a mosaic cell. */
+.tile--embed {
+  grid-column: 1 / -1;
 }
 
-/* The embedded LayoutSettings drops its standalone top margin so it reads as a
-   section within the panel rather than a separate page. */
-.appearance-settings .layout-settings {
+.tile--embed .layout-settings {
   margin-top: 0;
 }
 
-.appearance-settings .layout-settings-header p {
+.tile--embed .layout-settings-header p {
   margin-top: 2px;
 }
 
-/* Theme builder — preset row, color-slot grid, per-base reset. */
+/* --- Theme presets (hosted in a tile) ------------------------------------- */
 .theme-preset-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .theme-preset {
@@ -52,11 +54,12 @@
   align-items: center;
   gap: 6px;
   padding: 5px 10px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
-  background: var(--bg-tertiary);
+  background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 999px;
+  /* --radius-pill (999px), not --radius-full (50%) — a pill, not an ellipse. */
+  border-radius: var(--radius-pill);
   cursor: pointer;
 }
 
@@ -79,37 +82,15 @@
 .theme-preset__dot {
   width: 12px;
   height: 12px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   box-shadow: 0 0 0 1px var(--border-color-input) inset;
 }
 
-.theme-slots {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
-  margin: 4px 0 10px;
-}
-
-.theme-reset-base {
-  padding: 5px 12px;
-  font-size: 13px;
-  color: var(--text-secondary);
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  cursor: pointer;
-}
-
-.theme-reset-base:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-/* Prose background presets — chip with a live gradient preview. */
+/* --- Prose backdrop presets (hosted in a tile) ---------------------------- */
 .prose-bg-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: var(--space-2);
 }
 
 .prose-bg-option {
@@ -118,11 +99,11 @@
   align-items: center;
   gap: 4px;
   padding: 6px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   background: transparent;
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
 }
 
@@ -142,8 +123,20 @@
 }
 
 .prose-bg-preview {
-  width: 64px;
-  height: 40px;
-  border-radius: 5px;
+  width: 56px;
+  height: 34px;
+  border-radius: var(--radius-sm);
   box-shadow: 0 0 0 1px var(--border-color-input) inset;
+}
+
+/* --- ColorField inside a tile ---------------------------------------------
+   The field's own popover must escape the tile's `overflow: hidden`, so the
+   hosting tile opts out of clipping while a picker is open. */
+.tile--field {
+  overflow: visible;
+  contain: none;
+}
+
+.tile--field .color-field {
+  width: 100%;
 }

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -1,13 +1,42 @@
 /**
  * Settings → Appearance — the consolidated home for visual/UX configuration.
  *
- * Sections: Theme builder (base + presets + Primary/CTA/Surface/Text + Surprise
- * me), Motion, Density, Interface size, Canvas, Layout (embedded), and Title bar
- * (desktop-only). Kept self-contained (no coupling to `SettingsModal` internals)
- * so it survives the planned settings-menu rework.
+ * Built on the shared tile system (`../tiles/Tile`), so this panel and the
+ * layout menu read as one vocabulary (JP-253). The tile mosaic also let the
+ * thirteen one-and-two-row groups this panel used to carry collapse into five
+ * a reader can scan: Theme, Writing, Interface, Layout, Reset. (Canvas held a
+ * single control — grid opacity — and folded into Interface.)
+ *
+ * Every store binding, option set and piece of behaviour is unchanged from the
+ * row-based version — this is presentation only.
+ *
+ * Help text lives INSIDE its tile via the `hint` prop, not in a tooltip and not
+ * floating beside the mosaic. A tooltip is reachable only by hovering, which
+ * rules it out on touch entirely, and text sitting outside a tile reads as
+ * commentary on the group rather than on the control it belongs to.
  */
 
-import { Monitor, Moon, Sun, Wand2 } from 'lucide-react';
+import {
+  AppWindow,
+  Contrast,
+  Grid3x3,
+  Maximize,
+  Monitor,
+  Moon,
+  PanelsTopLeft,
+  RotateCcw,
+  Rows3,
+  Smartphone,
+  SpellCheck,
+  SquareDashed,
+  Sun,
+  SwatchBook,
+  Table,
+  TextCursorInput,
+  Type,
+  Wand2,
+  Zap,
+} from 'lucide-react';
 import { useSettingsStore } from '../../store/settingsStore';
 import { useThemeStore, type ThemePreference } from '../../store/themeStore';
 import {
@@ -36,10 +65,15 @@ import {
   THEME_SLOTS,
   surpriseTheme,
 } from '../appearance/themeEngine';
-import { SegmentedControl } from '../components/SegmentedControl';
-import { Slider } from '../components/Slider';
-import { Switch } from '../components/Switch';
 import { ColorField } from '../components/ColorField';
+import {
+  ActionTile,
+  CustomTile,
+  FillTile,
+  SegmentedTile,
+  TileGroup,
+  ToggleTile,
+} from '../tiles/Tile';
 import { resetAppearance } from '../appearance/appearanceConfig';
 import { LayoutSettings } from './LayoutSettings';
 import './AppearanceSettings.css';
@@ -69,7 +103,7 @@ const CARET_OPTIONS = [
 
 const SPELLCHECK_OPTIONS = [
   { value: 'custom' as const, label: 'Custom', title: "DocuShark's dictionary + Add to dictionary" },
-  { value: 'system' as const, label: 'System', title: "Your browser / OS spellchecker" },
+  { value: 'system' as const, label: 'System', title: 'Your browser / OS spellchecker' },
   { value: 'off' as const, label: 'Off', title: 'No spellchecking' },
 ];
 
@@ -105,6 +139,8 @@ export function AppearanceSettings() {
   const setSpellcheckMode = useUIPreferencesStore((s) => s.setSpellcheckMode);
   const roundedTables = useUIPreferencesStore((s) => s.appearancePrefs.roundedTables);
   const setRoundedTables = useUIPreferencesStore((s) => s.setRoundedTables);
+  const glass = useUIPreferencesStore((s) => s.appearancePrefs.glass);
+  const setGlass = useUIPreferencesStore((s) => s.setGlass);
   const gridOpacity = useSettingsStore((s) => s.gridOpacity);
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
 
@@ -135,26 +171,25 @@ export function AppearanceSettings() {
     <div className="appearance-settings">
       <h3 className="settings-section-title">Appearance</h3>
 
-      {/* Theme builder */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Theme</h4>
+      {/* ---------------------------------------------------------------- */}
+      <TileGroup title="Theme" icon={SwatchBook}>
+        <SegmentedTile
+          icon={Contrast}
+          label="Base"
+          ariaLabel="Theme base"
+          value={themePreference}
+          onValueChange={(v: ThemePreference) => setThemePreference(v)}
+          options={THEME_OPTIONS}
+          hint={`You're editing your ${activeBase} theme — switch base to customize the other independently.`}
+        />
 
-        <div className="settings-row">
-          <span className="settings-label">Base</span>
-          <SegmentedControl
-            ariaLabel="Theme base"
-            value={themePreference}
-            onValueChange={(v: ThemePreference) => setThemePreference(v)}
-            options={THEME_OPTIONS}
-          />
-          <span className="settings-hint">
-            Light or dark foundation. You're editing your <strong>{activeBase}</strong> theme;
-            switch base to customize the other independently.
-          </span>
-        </div>
-
-        <div className="settings-row">
-          <span className="settings-label">Presets</span>
+        <CustomTile
+          wide
+          icon={Wand2}
+          label="Presets"
+          value={activePresetId ? THEME_PRESETS.find((p) => p.id === activePresetId)?.label : 'Custom'}
+          hint="Start from a preset, then fine-tune the colors below."
+        >
           <div className="theme-preset-row">
             {THEME_PRESETS.map((preset) => (
               <button
@@ -180,13 +215,13 @@ export function AppearanceSettings() {
               <Wand2 size={14} aria-hidden="true" /> Surprise me
             </button>
           </div>
-          <span className="settings-hint">Start from a preset, then fine-tune the colors below.</span>
-        </div>
+        </CustomTile>
 
-        <div className="theme-slots">
-          {THEME_SLOTS.map(({ slot, label, hint }) => (
+        {/* ColorField renders its own label, hint, value and contrast warning,
+            and owns the picker popover — so the tile is a container only. */}
+        {THEME_SLOTS.map(({ slot, label, hint }) => (
+          <CustomTile key={slot} wide className="tile--field">
             <ColorField
-              key={slot}
               label={label}
               hint={hint}
               value={themeInputs[slot]}
@@ -194,26 +229,27 @@ export function AppearanceSettings() {
               onChange={(value) => setThemeInput(activeBase, slot, value)}
               {...(warnFor(slot) !== undefined ? { warning: warnFor(slot) as string } : {})}
             />
-          ))}
-        </div>
+          </CustomTile>
+        ))}
 
-        <div className="settings-row">
-          <button
-            type="button"
-            className="theme-reset-base"
-            disabled={Object.keys(themeInputs as ThemeInputs).length === 0}
-            onClick={() => setThemeInputs(activeBase, {})}
-          >
-            Reset {activeBase} theme to default
-          </button>
-        </div>
-      </div>
+        <ActionTile
+          icon={RotateCcw}
+          label={`Reset ${activeBase} theme`}
+          value="Back to base"
+          disabled={Object.keys(themeInputs as ThemeInputs).length === 0}
+          onClick={() => setThemeInputs(activeBase, {})}
+        />
+      </TileGroup>
 
-      {/* Prose background */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Prose background</h4>
-        <div className="settings-row">
-          <span className="settings-label">Editor backdrop</span>
+      {/* ---------------------------------------------------------------- */}
+      <TileGroup title="Writing" icon={Type}>
+        <CustomTile
+          wide
+          icon={SquareDashed}
+          label="Prose background"
+          value={PROSE_BACKGROUNDS[proseBackground].label}
+          hint="The backdrop behind the writing area. Presets follow your theme colors."
+        >
           <div className="prose-bg-row">
             {(Object.keys(PROSE_BACKGROUNDS) as ProseBackground[]).map((id) => (
               <button
@@ -222,6 +258,7 @@ export function AppearanceSettings() {
                 className={`prose-bg-option${proseBackground === id ? ' is-active' : ''}`}
                 onClick={() => setProseBackground(id)}
                 aria-pressed={proseBackground === id}
+                title={PROSE_BACKGROUNDS[id].label}
               >
                 <span
                   className="prose-bg-preview"
@@ -232,186 +269,137 @@ export function AppearanceSettings() {
               </button>
             ))}
           </div>
-          <span className="settings-hint">
-            The backdrop behind the writing area. Presets follow your theme colors.
-          </span>
-        </div>
-      </div>
+        </CustomTile>
 
-      {/* Caret */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Caret</h4>
-        <div className="settings-row">
-          <span className="settings-label">Style</span>
-          <SegmentedControl
-            ariaLabel="Caret style"
-            value={caretStyle}
-            onValueChange={(v: CaretStyle) => setCaretStyle(v)}
-            options={CARET_OPTIONS}
-          />
-          <span className="settings-hint">
-            The text cursor shape in the writing editor.
-          </span>
-        </div>
-        <div className="settings-row">
-          <span className="settings-label">Smooth writing</span>
-          <Switch
-            ariaLabel="Smooth caret"
-            checked={smoothCaret}
-            onCheckedChange={setSmoothCaret}
-          />
-          <span className="settings-hint">
-            Glide the caret between positions as you type instead of jumping.
-            Automatically off when interface motion is reduced.
-          </span>
-        </div>
-        <ColorField
-          label="Color"
-          hint="The writing caret's color. Defaults to the theme text color; applies to the block / smooth caret."
-          value={caretColor ?? undefined}
-          defaultSwatch="#0a1525"
-          onChange={(value) => setCaretColor(value ?? null)}
+        <SegmentedTile
+          icon={TextCursorInput}
+          label="Caret style"
+          value={caretStyle}
+          onValueChange={(v: CaretStyle) => setCaretStyle(v)}
+          options={CARET_OPTIONS}
+          hint="The text cursor shape in the writing editor."
         />
-      </div>
 
-      {/* Spelling */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Spelling</h4>
-        <div className="settings-row">
-          <span className="settings-label">Spellcheck</span>
-          <SegmentedControl
-            ariaLabel="Spellcheck"
-            value={spellcheck}
-            onValueChange={(v: SpellcheckMode) => setSpellcheckMode(v)}
-            options={SPELLCHECK_OPTIONS}
+        <ToggleTile
+          icon={Type}
+          label="Smooth writing"
+          checked={smoothCaret}
+          onCheckedChange={setSmoothCaret}
+          hint="Glides between positions as you type. Off automatically when motion is reduced."
+        />
+
+        <ToggleTile
+          icon={Table}
+          label="Rounded tables"
+          checked={roundedTables}
+          onCheckedChange={setRoundedTables}
+          hint="Off gives square, grid-style tables."
+        />
+
+        <CustomTile wide className="tile--field">
+          <ColorField
+            label="Caret color"
+            hint="Defaults to the theme text color; applies to the block / smooth caret."
+            value={caretColor ?? undefined}
+            defaultSwatch="#0a1525"
+            onChange={(value) => setCaretColor(value ?? null)}
           />
-          <span className="settings-hint">
-            <strong>Custom</strong> uses DocuShark's dictionary and “Add to dictionary”.
-            <strong> System</strong> uses your browser/OS spellchecker.
-            <strong> Off</strong> disables spellchecking. Only one runs at a time.
+        </CustomTile>
+
+        <SegmentedTile
+          icon={SpellCheck}
+          label="Spellcheck"
+          value={spellcheck}
+          onValueChange={(v: SpellcheckMode) => setSpellcheckMode(v)}
+          options={SPELLCHECK_OPTIONS}
+          hint="Custom uses DocuShark's dictionary and “Add to dictionary”; System uses your browser or OS checker. Only one runs at a time."
+        />
+      </TileGroup>
+
+      {/* ---------------------------------------------------------------- */}
+      <TileGroup title="Interface" icon={Rows3}>
+        <FillTile
+          icon={Maximize}
+          label="Interface size"
+          value={uiScalePercent}
+          onValueChange={(pct) => setUiScale(pct / 100)}
+          min={Math.round(UI_SCALE_MIN * 100)}
+          max={Math.round(UI_SCALE_MAX * 100)}
+          step={5}
+          hint="The canvas and your diagrams are not affected."
+        />
+
+        <FillTile
+          icon={Grid3x3}
+          label="Grid opacity"
+          value={gridOpacity}
+          onValueChange={setGridOpacity}
+          min={0}
+          max={100}
+          step={5}
+          hint="0 hides the grid entirely."
+        />
+
+        <SegmentedTile
+          icon={Rows3}
+          label="Density"
+          ariaLabel="Spacing density"
+          value={density}
+          onValueChange={(v: Density) => setDensity(v)}
+          options={DENSITY_OPTIONS}
+          hint="Compact fits more on screen; Spacious gives larger, easier targets."
+        />
+
+        <SegmentedTile
+          icon={Zap}
+          label="Motion"
+          ariaLabel="Interface animations"
+          value={motion}
+          onValueChange={(v: MotionPreference) => setMotion(v)}
+          options={MOTION_OPTIONS}
+          hint="System follows your device's accessibility setting."
+        />
+
+        <ToggleTile
+          icon={Contrast}
+          label="Glass chrome"
+          checked={glass}
+          onCheckedChange={setGlass}
+          hint="Translucent, blurred panels. Off is flat and opaque — lighter to render."
+        />
+
+        <MobilePreviewTile />
+        <TitleBarTile />
+      </TileGroup>
+
+      {/* Layout — the panel-arrangement editor. A full sub-panel of per-layout
+          dock dropdowns rather than a control, so it keeps its own rows inside
+          one tile-styled surface instead of being forced into the mosaic.
+          Converting it is a follow-up alongside the other Settings tabs. */}
+      <section className="tile-group">
+        <div className="tile-group__head">
+          <span className="tile-group__icon" aria-hidden="true">
+            <PanelsTopLeft size={15} strokeWidth={1.5} />
           </span>
+          <h4 className="tile-group__title">Layout</h4>
+          <span className="tile-group__rule" aria-hidden="true" />
         </div>
-      </div>
-
-      {/* Tables */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Tables</h4>
-        <div className="settings-row">
-          <span className="settings-label">Rounded tables</span>
-          <Switch
-            ariaLabel="Rounded tables"
-            checked={roundedTables}
-            onCheckedChange={setRoundedTables}
-          />
-          <span className="settings-hint">
-            Round the corners of tables in the writing editor. Turn off for square,
-            grid-style tables.
-          </span>
+        <div className="tile tile--embed">
+          <LayoutSettings embedded />
         </div>
-      </div>
+      </section>
 
-      {/* Motion */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Motion</h4>
-        <div className="settings-row">
-          <span className="settings-label">Interface animations</span>
-          <SegmentedControl
-            ariaLabel="Interface animations"
-            value={motion}
-            onValueChange={(v: MotionPreference) => setMotion(v)}
-            options={MOTION_OPTIONS}
-          />
-          <span className="settings-hint">
-            Reduce or turn off interface animations. "System" follows your device's
-            accessibility setting.
-          </span>
-        </div>
-      </div>
-
-      {/* Density */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Density</h4>
-        <div className="settings-row">
-          <span className="settings-label">Spacing</span>
-          <SegmentedControl
-            ariaLabel="Spacing density"
-            value={density}
-            onValueChange={(v: Density) => setDensity(v)}
-            options={DENSITY_OPTIONS}
-          />
-          <span className="settings-hint">
-            Tighten or loosen spacing throughout the app. Compact fits more on screen;
-            Spacious gives larger, easier targets.
-          </span>
-        </div>
-      </div>
-
-      {/* Interface size */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Interface size</h4>
-        <div className="settings-row">
-          <label className="settings-label" htmlFor="ui-scale">
-            Size
-          </label>
-          <div className="settings-slider-row">
-            <Slider
-              ariaLabel="Interface size"
-              value={uiScalePercent}
-              onValueChange={(pct) => setUiScale(pct / 100)}
-              min={Math.round(UI_SCALE_MIN * 100)}
-              max={Math.round(UI_SCALE_MAX * 100)}
-              step={5}
-            />
-            <span className="settings-slider-value">{uiScalePercent}%</span>
-          </div>
-          <span className="settings-hint">
-            Scale the whole interface up or down. The canvas and your diagrams are
-            not affected.
-          </span>
-        </div>
-      </div>
-
-      {/* Canvas */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Canvas</h4>
-        <div className="settings-row">
-          <label className="settings-label" htmlFor="grid-opacity">
-            Grid opacity
-          </label>
-          <div className="settings-slider-row">
-            <input
-              id="grid-opacity"
-              type="range"
-              className="styled-slider"
-              min={0}
-              max={100}
-              value={gridOpacity}
-              onChange={(e) => setGridOpacity(Number(e.target.value))}
-            />
-            <span className="settings-slider-value">{gridOpacity}%</span>
-          </div>
-          <span className="settings-hint">
-            Adjust how visible the canvas grid is (0 = hidden).
-          </span>
-        </div>
-      </div>
-
-      {/* Layout — the panel-arrangement editor, embedded as a section. */}
-      <LayoutSettings embedded />
-
-      {/* Title bar — desktop-only; renders nothing on the web app. */}
-      <TitleBarSection />
-
-      {/* Mobile preview — the experimental small-screen layout (JP-332). */}
-      <MobilePreviewSection />
-
-      {/* Reset */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Reset</h4>
-        <button type="button" className="settings-reset-btn" onClick={handleReset}>
-          Reset appearance to defaults
-        </button>
-      </div>
+      {/* ---------------------------------------------------------------- */}
+      <TileGroup title="Reset" icon={RotateCcw}>
+        <ActionTile
+          danger
+          icon={RotateCcw}
+          label="Reset appearance"
+          value="Back to defaults"
+          onClick={handleReset}
+          hint="Theme, motion, density, interface size and layout customization."
+        />
+      </TileGroup>
     </div>
   );
 }
@@ -424,7 +412,7 @@ export function AppearanceSettings() {
  * everywhere so an opted-out user (or a desktop user testing a narrow window)
  * has a discoverable, non-nagging way back in.
  */
-function MobilePreviewSection() {
+function MobilePreviewTile() {
   const accepted = useUIPreferencesStore((s) => s.mobilePreviewAccepted);
   const forceDesktop = useUIPreferencesStore((s) => s.forceDesktopSite);
   const setMobilePreviewAccepted = useUIPreferencesStore((s) => s.setMobilePreviewAccepted);
@@ -442,34 +430,22 @@ function MobilePreviewSection() {
   };
 
   return (
-    <div className="settings-group">
-      <h4 className="settings-group-title">Mobile preview</h4>
-      <div className="settings-row settings-row-switch">
-        <label className="settings-switch-label" htmlFor="docushark-mobile-preview">
-          <Switch
-            id="docushark-mobile-preview"
-            checked={enabled}
-            onCheckedChange={handleToggle}
-            ariaLabel="Use the mobile preview layout"
-          />
-          <span className="settings-switch-text">Use the mobile preview layout</span>
-        </label>
-        <span className="settings-hint">
-          An experimental, early-access layout for small touch screens. Only takes
-          effect on a touch device with a small screen; turn it off to always use the
-          desktop layout.
-        </span>
-      </div>
-    </div>
+    <ToggleTile
+      icon={Smartphone}
+      label="Mobile preview"
+      checked={enabled}
+      onCheckedChange={handleToggle}
+      hint="Experimental. Only takes effect on a touch device with a small screen."
+    />
   );
 }
 
 /**
  * DocuShark title bar opt-in. Gated to the desktop shell that owns a native
  * title bar — `windowControls.isSupported()` is false on the web app (and we
- * exclude macOS) — so the whole section is absent there (JP-107).
+ * exclude macOS) — so the tile is absent there (JP-107).
  */
-function TitleBarSection() {
+function TitleBarTile() {
   const customChrome = useUIPreferencesStore((s) => s.layout.customChrome);
   const setCustomChrome = useUIPreferencesStore((s) => s.setCustomChrome);
 
@@ -499,23 +475,12 @@ function TitleBarSection() {
   };
 
   return (
-    <div className="settings-group">
-      <h4 className="settings-group-title">Title bar</h4>
-      <div className="settings-row settings-row-switch">
-        <label className="settings-switch-label" htmlFor="docushark-title-bar">
-          <Switch
-            id="docushark-title-bar"
-            checked={customChrome}
-            onCheckedChange={handleToggle}
-            ariaLabel="Use DocuShark's title bar"
-          />
-          <span className="settings-switch-text">Use DocuShark's title bar</span>
-        </label>
-        <span className="settings-hint">
-          Replace your operating system's window title bar with DocuShark's own for a
-          more unified look. The app restarts to apply.
-        </span>
-      </div>
-    </div>
+    <ToggleTile
+      icon={AppWindow}
+      label="DocuShark title bar"
+      checked={customChrome}
+      onCheckedChange={handleToggle}
+      hint="Replaces your system window title bar. The app restarts to apply."
+    />
   );
 }

--- a/src/ui/settings/GeneralSettings.css
+++ b/src/ui/settings/GeneralSettings.css
@@ -1,6 +1,17 @@
-/* General Settings */
+/* General Settings.
+ *
+ * NOTE: this file also defines the shared `.settings-group` / `.settings-row` /
+ * `.settings-label` / `.settings-hint` classes that the not-yet-converted tabs
+ * (Backup & Restore, the embedded Layout editor) still rely on. Those stay
+ * until the last row-based surface is converted. */
 .general-settings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
   padding: 4px 0;
+  /* Query container for the tile container queries — tiles reflow against this
+     panel's width, not the window's. */
+  container-type: inline-size;
 }
 
 .settings-section-title {

--- a/src/ui/settings/GeneralSettings.tsx
+++ b/src/ui/settings/GeneralSettings.tsx
@@ -1,19 +1,26 @@
 /**
- * General Settings component for the Settings modal.
+ * General Settings component for the Settings sheet.
  *
  * Contains:
  * - Default style profile
  * - Show/hide static properties
  * - Hide default style profiles
+ * - Minimap + layer-click focus
  *
  * (The connector routing default moved to last-used memory, set from the
  * canvas toolbar's connector dropdown — there's no knob for it here anymore.)
+ *
+ * On the shared tile system (JP-253), same as Appearance. The four checkboxes
+ * become toggle tiles: a checkbox plus a separate label plus a hint below was
+ * three elements to say one thing.
  */
 
 import { useMemo } from 'react';
+import { Crosshair, Eye, EyeOff, Map, Palette, RotateCcw, Shapes, Monitor } from 'lucide-react';
 import { useSettingsStore } from '../../store/settingsStore';
 import { useStyleProfileStore } from '../../store/styleProfileStore';
 import { RichSelect, type RichSelectItem } from '../components/RichSelect';
+import { ActionTile, CustomTile, TileGroup, ToggleTile } from '../tiles/Tile';
 import './GeneralSettings.css';
 
 export function GeneralSettings() {
@@ -45,18 +52,21 @@ export function GeneralSettings() {
     [profiles, hideDefaultStyleProfiles]
   );
 
+  const activeProfileName =
+    styleProfileItems.find((i) => i.value === (defaultStyleProfileId ?? ''))?.label ?? 'None';
+
   return (
     <div className="general-settings">
-      <h3 className="settings-section-title">General Settings</h3>
+      <h3 className="settings-section-title">General</h3>
 
-      {/* Style Settings */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Shapes</h4>
-
-        <div className="settings-row">
-          <label className="settings-label">
-            Default Style Profile
-          </label>
+      <TileGroup title="Shapes" icon={Shapes}>
+        <CustomTile
+          wide
+          icon={Palette}
+          label="Default style profile"
+          value={activeProfileName}
+          hint="New shapes are created with this style applied."
+        >
           <RichSelect
             value={defaultStyleProfileId ?? ''}
             onChange={handleStyleProfileChange}
@@ -65,91 +75,57 @@ export function GeneralSettings() {
             className="settings-select"
             align="end"
           />
-          <span className="settings-hint">
-            New shapes will be created with this style applied
-          </span>
-        </div>
-      </div>
+        </CustomTile>
+      </TileGroup>
 
-      {/* Display Settings */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Display</h4>
+      <TileGroup title="Display" icon={Monitor}>
+        <ToggleTile
+          icon={Eye}
+          label="Static properties"
+          checked={showStaticProperties}
+          onCheckedChange={setShowStaticProperties}
+          hint="Show read-only properties (like ID) in the Property Panel."
+        />
 
-        <div className="settings-row settings-row-checkbox">
-          <label className="settings-checkbox-label">
-            <input
-              type="checkbox"
-              className="settings-checkbox"
-              checked={showStaticProperties}
-              onChange={(e) => setShowStaticProperties(e.target.checked)}
-            />
-            <span className="settings-checkbox-text">Show Static Properties</span>
-          </label>
-          <span className="settings-hint">
-            Display read-only properties (like ID) in the Property Panel
-          </span>
-        </div>
+        <ToggleTile
+          icon={EyeOff}
+          label="Hide default style profiles"
+          checked={hideDefaultStyleProfiles}
+          onCheckedChange={setHideDefaultStyleProfiles}
+          hint="Show only your custom profiles in the Property Panel."
+        />
 
-        <div className="settings-row settings-row-checkbox">
-          <label className="settings-checkbox-label">
-            <input
-              type="checkbox"
-              className="settings-checkbox"
-              checked={hideDefaultStyleProfiles}
-              onChange={(e) => setHideDefaultStyleProfiles(e.target.checked)}
-            />
-            <span className="settings-checkbox-text">Hide Default Style Profiles</span>
-          </label>
-          <span className="settings-hint">
-            Only show custom style profiles in the Property Panel
-          </span>
-        </div>
+        <ToggleTile
+          icon={Map}
+          label="Minimap"
+          checked={showMinimap}
+          onCheckedChange={setShowMinimap}
+          hint="Experimental. Helps navigate large canvases."
+        />
 
-        <div className="settings-row settings-row-checkbox">
-          <label className="settings-checkbox-label">
-            <input
-              type="checkbox"
-              className="settings-checkbox"
-              checked={showMinimap}
-              onChange={(e) => setShowMinimap(e.target.checked)}
-            />
-            <span className="settings-checkbox-text">Show Minimap (Experimental)</span>
-          </label>
-          <span className="settings-hint">
-            Display a minimap for navigating large canvases
-          </span>
-        </div>
+        <ToggleTile
+          icon={Crosshair}
+          label="Auto-focus on layer click"
+          checked={layerClickFocusShape}
+          onCheckedChange={setLayerClickFocusShape}
+          hint="Pan the camera to a shape when you click it in the Layers panel."
+        />
+      </TileGroup>
 
-        <div className="settings-row settings-row-checkbox">
-          <label className="settings-checkbox-label">
-            <input
-              type="checkbox"
-              className="settings-checkbox"
-              checked={layerClickFocusShape}
-              onChange={(e) => setLayerClickFocusShape(e.target.checked)}
-            />
-            <span className="settings-checkbox-text">Auto-focus on layer click</span>
-          </label>
-          <span className="settings-hint">
-            Automatically pan camera to shape when clicking in the layer panel
-          </span>
-        </div>
-      </div>
-
-      {/* Reset Settings */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Reset</h4>
-        <button
-          className="settings-reset-btn"
+      <TileGroup title="Reset" icon={RotateCcw}>
+        <ActionTile
+          danger
+          icon={RotateCcw}
+          label="Reset settings"
+          value="Back to defaults"
           onClick={() => {
             if (confirm('Reset all settings to defaults?')) {
               resetSettings();
             }
           }}
-        >
-          Reset to Defaults
-        </button>
-      </div>
+          hint="Everything on this tab, restored to its shipped value."
+        />
+      </TileGroup>
     </div>
   );
 }

--- a/src/ui/settings/StyleProfileSettings.css
+++ b/src/ui/settings/StyleProfileSettings.css
@@ -1,6 +1,11 @@
 /* Style Profile Settings */
 .style-profile-settings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
   padding: 4px 0;
+  /* Query container for the tile container queries. */
+  container-type: inline-size;
 }
 
 .settings-description {

--- a/src/ui/settings/StyleProfileSettings.tsx
+++ b/src/ui/settings/StyleProfileSettings.tsx
@@ -1,12 +1,13 @@
 /**
- * Style Profile Settings component for the Settings modal.
+ * Style Profile Settings component for the Settings sheet.
  *
- * Contains settings for style profile behavior:
- * - Save icon style to profiles
- * - Save label style to profiles
+ * What gets captured when a new style profile is created from a shape.
+ * On the shared tile system (JP-253).
  */
 
+import { Info, Palette, Tag, Type } from 'lucide-react';
 import { useSettingsStore } from '../../store/settingsStore';
+import { StatusTile, TileGroup, ToggleTile } from '../tiles/Tile';
 import './StyleProfileSettings.css';
 
 export function StyleProfileSettings() {
@@ -17,55 +18,36 @@ export function StyleProfileSettings() {
 
   return (
     <div className="style-profile-settings">
-      <h3 className="settings-section-title">Style Profile Settings</h3>
+      <h3 className="settings-section-title">Style Profiles</h3>
 
       <p className="settings-description">
-        Configure what properties are saved when creating a new style profile from a shape.
+        What gets captured when you create a new style profile from a shape.
       </p>
 
-      {/* Save Options */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Properties to Include</h4>
+      <TileGroup title="Properties to include" icon={Palette}>
+        <ToggleTile
+          icon={Tag}
+          label="Icon style"
+          checked={saveIconStyleToProfile}
+          onCheckedChange={setSaveIconStyleToProfile}
+          hint="Icon ID, size and padding."
+        />
 
-        <div className="settings-row settings-row-checkbox">
-          <label className="settings-checkbox-label">
-            <input
-              type="checkbox"
-              className="settings-checkbox"
-              checked={saveIconStyleToProfile}
-              onChange={(e) => setSaveIconStyleToProfile(e.target.checked)}
-            />
-            <span className="settings-checkbox-text">Save Icon Style to Profile</span>
-          </label>
-          <span className="settings-hint">
-            Include icon ID, size, and padding when saving a style profile
-          </span>
-        </div>
+        <ToggleTile
+          icon={Type}
+          label="Label style"
+          checked={saveLabelStyleToProfile}
+          onCheckedChange={setSaveLabelStyleToProfile}
+          hint="Label font size, color, background and offset."
+        />
 
-        <div className="settings-row settings-row-checkbox">
-          <label className="settings-checkbox-label">
-            <input
-              type="checkbox"
-              className="settings-checkbox"
-              checked={saveLabelStyleToProfile}
-              onChange={(e) => setSaveLabelStyleToProfile(e.target.checked)}
-            />
-            <span className="settings-checkbox-text">Save Label Style to Profile</span>
-          </label>
-          <span className="settings-hint">
-            Include label font size, color, background, and offset when saving a style profile
-          </span>
-        </div>
-      </div>
-
-      {/* Info */}
-      <div className="settings-info-box">
-        <div className="settings-info-icon">i</div>
-        <div className="settings-info-content">
-          <strong>Note:</strong> These settings affect new profiles only. Existing profiles
-          retain their saved properties regardless of these settings.
-        </div>
-      </div>
+        <StatusTile
+          icon={Info}
+          label="Scope"
+          value="New profiles only"
+          hint="Existing profiles keep the properties they were saved with, whatever these are set to now."
+        />
+      </TileGroup>
     </div>
   );
 }

--- a/src/ui/tiles/Tile.tsx
+++ b/src/ui/tiles/Tile.tsx
@@ -1,0 +1,569 @@
+/**
+ * Tile — the shared anatomy of every control in the tile system (JP-253).
+ *
+ * One vocabulary, used by both the layout menu and Settings, so the two read as
+ * one system rather than two surfaces that happen to share a palette.
+ *
+ * Every tile opens the same way: a tinted **icon chip**, then a **title**, then
+ * an optional **value** line, then whatever control it owns. That repetition is
+ * the whole point — it is what makes a wall of thirty settings scannable, and it
+ * is why the colour-slot tile puts its swatch *in the chip* instead of inventing
+ * a bespoke layout (a tile that breaks the anatomy reads as mis-spaced, not as
+ * special).
+ *
+ * Footprints: 1x1 by default, `wide` (2 columns) for anything carrying a
+ * horizontal control, `tall` (2 rows) for the fill slider. `TileGrid` reflows
+ * them; see `tiles.css` for the mosaic and its two container queries.
+ *
+ * These components own **presentation only**. Keyboard and ARIA behaviour comes
+ * from the existing brand-tokened primitives in `../components` (Radix-backed
+ * Switch / SegmentedControl / Slider), which are wrapped here, never
+ * reimplemented.
+ */
+
+import type { LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Icon } from '../icons';
+import { SegmentedControl, type SegmentedOption } from '../components/SegmentedControl';
+import { Slider } from '../components/Slider';
+import './tiles.css';
+
+// ---------------------------------------------------------------------------
+// Grid
+// ---------------------------------------------------------------------------
+
+export interface TileGridProps {
+  children: ReactNode;
+  /**
+   * Column floor (px). The grid fits as many columns of at least this width as
+   * it can. 150 suits a settings sheet; a ~340px popover wants ~132 so it still
+   * gets two columns.
+   */
+  min?: number;
+  /** Row floor (px). Rows grow past it when their content needs the room. */
+  row?: number;
+  className?: string;
+}
+
+/**
+ * The mosaic. `auto-fill` + `minmax` means there is no breakpoint list to
+ * maintain — the column count falls out of the available width.
+ *
+ * `grid-auto-rows` is a *floor*, not a fixed height: chip (30) + gap + control
+ * (30) + padding (20) already exceeds a naive row, and every one of those
+ * numbers moves again with `--density-mult` and `--ui-scale`. A constant row
+ * height silently clips the bottom of every segmented control at some density,
+ * which is exactly the defect `tiles.test.tsx` pins.
+ */
+export function TileGrid({ children, min = 150, row = 86, className = '' }: TileGridProps) {
+  return (
+    <div
+      className={`tile-grid ${className}`.trim()}
+      style={{ '--tile-min': `${min}px`, '--tile-row': `${row}px` } as React.CSSProperties}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface TileGroupProps {
+  title: string;
+  icon: LucideIcon;
+  children: ReactNode;
+  /** Column floor passed through to the grid. */
+  min?: number;
+  row?: number;
+}
+
+/** An icon-led section header over one mosaic. */
+export function TileGroup({ title, icon, children, min, row }: TileGroupProps) {
+  return (
+    <section className="tile-group">
+      <div className="tile-group__head">
+        <span className="tile-group__icon" aria-hidden="true">
+          <Icon icon={icon} size={15} />
+        </span>
+        <h4 className="tile-group__title">{title}</h4>
+        <span className="tile-group__rule" aria-hidden="true" />
+      </div>
+      <TileGrid {...(min !== undefined ? { min } : {})} {...(row !== undefined ? { row } : {})}>
+        {children}
+      </TileGrid>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared pieces
+// ---------------------------------------------------------------------------
+
+/** Footprint + styling props every tile accepts. */
+interface TileBaseProps {
+  /** Span two columns. */
+  wide?: boolean;
+  /** Span two rows. */
+  tall?: boolean;
+  className?: string;
+  /** Native tooltip — where a row's hint text goes in the tile layout. */
+  title?: string;
+}
+
+function footprint({ wide, tall, className = '' }: TileBaseProps): string {
+  return ['tile', wide ? 'tile--w2' : '', tall ? 'tile--h2' : '', className]
+    .filter(Boolean)
+    .join(' ');
+}
+
+interface TileHeadProps {
+  icon?: LucideIcon;
+  /** Replaces the glyph entirely (the colour swatch, a layout thumbnail). */
+  chip?: ReactNode;
+  chipStyle?: React.CSSProperties;
+  title: string;
+  value?: string | undefined;
+  trailing?: ReactNode;
+}
+
+function TileHead({ icon, chip, chipStyle, title, value, trailing }: TileHeadProps) {
+  return (
+    <div className="tile__head">
+      <span className="tile__chip" style={chipStyle} aria-hidden="true">
+        {chip ?? (icon ? <Icon icon={icon} /> : null)}
+      </span>
+      <span className="tile__text">
+        <span className="tile__title">{title}</span>
+        {value != null && <span className="tile__value">{value}</span>}
+      </span>
+      {trailing}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 1. Toggle tile — the Control Centre hero
+// ---------------------------------------------------------------------------
+
+export interface ToggleTileProps extends TileBaseProps {
+  icon: LucideIcon;
+  label: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  /** State words. Default On/Off. */
+  onLabel?: string;
+  offLabel?: string;
+  disabled?: boolean;
+  /** Replaces the state word — e.g. "on selection" for a layout-owned panel. */
+  note?: string;
+  /** Render as a compact row (icon + label only) — for popovers. */
+  compact?: boolean;
+}
+
+/**
+ * The whole tile is the switch. `role="switch"` + `aria-checked` carries the
+ * semantics; the visual state is the accent bloom in `tiles.css`.
+ */
+export function ToggleTile({
+  icon,
+  label,
+  checked,
+  onCheckedChange,
+  onLabel = 'On',
+  offLabel = 'Off',
+  disabled = false,
+  note,
+  compact = false,
+  ...base
+}: ToggleTileProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      // A switch is named for the thing, not the action — the role plus
+      // aria-checked already carry "toggles".
+      aria-label={label}
+      className={footprint({
+        ...base,
+        className: `tile--toggle ${compact ? 'tile--chip' : ''} ${base.className ?? ''}`,
+      })}
+      onClick={() => onCheckedChange(!checked)}
+      {...(base.title !== undefined ? { title: base.title } : {})}
+    >
+      <TileHead icon={icon} title={label} value={note ?? (checked ? onLabel : offLabel)} />
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Segmented tile
+// ---------------------------------------------------------------------------
+
+export interface SegmentedTileProps<T extends string> extends TileBaseProps {
+  icon: LucideIcon;
+  label: string;
+  value: T;
+  onValueChange: (value: T) => void;
+  options: ReadonlyArray<SegmentedOption<T>>;
+}
+
+/** Wraps the real `SegmentedControl`, so roving-tabindex + radiogroup semantics
+ *  are inherited rather than re-invented. */
+export function SegmentedTile<T extends string>({
+  icon,
+  label,
+  value,
+  onValueChange,
+  options,
+  ...base
+}: SegmentedTileProps<T>) {
+  return (
+    <div className={footprint({ wide: true, ...base })} {...(base.title !== undefined ? { title: base.title } : {})}>
+      <TileHead icon={icon} title={label} />
+      <div className="tile__body">
+        <SegmentedControl
+          ariaLabel={label}
+          value={value}
+          onValueChange={onValueChange}
+          options={options}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Slider tile
+// ---------------------------------------------------------------------------
+
+export interface SliderTileProps extends TileBaseProps {
+  icon: LucideIcon;
+  label: string;
+  value: number;
+  onValueChange: (value: number) => void;
+  min: number;
+  max: number;
+  step?: number;
+  /** Suffix on the readout — "%", "s", … */
+  unit?: string;
+}
+
+export function SliderTile({
+  icon,
+  label,
+  value,
+  onValueChange,
+  min,
+  max,
+  step = 1,
+  unit = '%',
+  ...base
+}: SliderTileProps) {
+  return (
+    <div className={footprint({ wide: true, ...base })} {...(base.title !== undefined ? { title: base.title } : {})}>
+      <TileHead
+        icon={icon}
+        title={label}
+        trailing={
+          <span className="tile__metric">
+            {value}
+            {unit}
+          </span>
+        }
+      />
+      <div className="tile__body tile__body--slider">
+        <Slider
+          ariaLabel={label}
+          value={value}
+          onValueChange={onValueChange}
+          min={min}
+          max={max}
+          step={step}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Fill tile — the Control Centre brightness bar
+// ---------------------------------------------------------------------------
+
+export interface FillTileProps extends TileBaseProps {
+  icon: LucideIcon;
+  label: string;
+  value: number;
+  onValueChange: (value: number) => void;
+  min: number;
+  max: number;
+  step?: number;
+  unit?: string;
+}
+
+/**
+ * Drag anywhere on the tile. The axis is declared in CSS (`--fill-axis`) so the
+ * container query that rotates the tile at narrow widths also rotates the drag —
+ * the pointer maths reads the axis rather than guessing from the aspect ratio.
+ *
+ * `role="slider"` with arrow-key handling, because this is a real control and
+ * the drag surface is not keyboard-reachable on its own.
+ */
+export function FillTile({
+  icon,
+  label,
+  value,
+  onValueChange,
+  min,
+  max,
+  step = 5,
+  unit = '%',
+  ...base
+}: FillTileProps) {
+  const pct = ((value - min) / (max - min)) * 100;
+
+  const setFromPointer = (el: HTMLElement, clientX: number, clientY: number) => {
+    const r = el.getBoundingClientRect();
+    const axis = getComputedStyle(el).getPropertyValue('--fill-axis').trim();
+    const ratio = axis === 'x' ? (clientX - r.left) / r.width : 1 - (clientY - r.top) / r.height;
+    const next = min + Math.min(1, Math.max(0, ratio)) * (max - min);
+    onValueChange(Math.round(next / step) * step);
+  };
+
+  const clamp = (v: number) => Math.min(max, Math.max(min, v));
+
+  return (
+    <div
+      className={footprint({ tall: true, ...base, className: `tile--fill ${base.className ?? ''}` })}
+      role="slider"
+      tabIndex={0}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={value}
+      aria-label={label}
+      style={{ '--level': `${pct}%` } as React.CSSProperties}
+      {...(base.title !== undefined ? { title: base.title } : {})}
+      onPointerDown={(e) => {
+        const el = e.currentTarget;
+        el.setPointerCapture(e.pointerId);
+        setFromPointer(el, e.clientX, e.clientY);
+      }}
+      onPointerMove={(e) => {
+        if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
+        setFromPointer(e.currentTarget, e.clientX, e.clientY);
+      }}
+      onKeyDown={(e) => {
+        const jump = e.shiftKey ? step * 2 : step;
+        if (e.key === 'ArrowUp' || e.key === 'ArrowRight') {
+          onValueChange(clamp(value + jump));
+          e.preventDefault();
+        } else if (e.key === 'ArrowDown' || e.key === 'ArrowLeft') {
+          onValueChange(clamp(value - jump));
+          e.preventDefault();
+        } else if (e.key === 'Home') {
+          onValueChange(min);
+          e.preventDefault();
+        } else if (e.key === 'End') {
+          onValueChange(max);
+          e.preventDefault();
+        }
+      }}
+    >
+      <span className="fill__level" aria-hidden="true" />
+      <span className="fill__content">
+        <span className="fill__icon" aria-hidden="true">
+          <Icon icon={icon} />
+        </span>
+        <span className="fill__foot">
+          <span className="fill__metric">
+            {value}
+            {unit}
+          </span>
+          <span className="fill__label">{label}</span>
+        </span>
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Swatch tile
+// ---------------------------------------------------------------------------
+
+export interface SwatchTileProps extends TileBaseProps {
+  label: string;
+  /** The resolved colour to show. */
+  swatch: string;
+  /** No explicit value set — the theme engine derives it. */
+  derived?: boolean;
+  /** Display value under the title (a hex, usually). */
+  value?: string;
+  onClick?: () => void;
+}
+
+/** The swatch *is* the icon chip — see the anatomy note at the top of the file. */
+export function SwatchTile({
+  label,
+  swatch,
+  derived = false,
+  value,
+  onClick,
+  ...base
+}: SwatchTileProps) {
+  return (
+    <button
+      type="button"
+      className={footprint({ ...base, className: `tile--swatch ${base.className ?? ''}` })}
+      onClick={onClick}
+      {...(base.title !== undefined ? { title: base.title } : {})}
+    >
+      <TileHead
+        chip={null}
+        chipStyle={{ background: swatch }}
+        title={label}
+        value={derived ? 'Derived' : value}
+        trailing={derived ? <span className="tile__badge">Auto</span> : undefined}
+      />
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Picker tile
+// ---------------------------------------------------------------------------
+
+export interface PickerTileProps extends TileBaseProps {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  onClick?: () => void;
+  /** Small colour dots under the title (theme presets). */
+  dots?: readonly string[];
+  /** Expanded state, when the tile opens an inline sub-sheet. */
+  expanded?: boolean;
+}
+
+export function PickerTile({
+  icon,
+  label,
+  value,
+  onClick,
+  dots,
+  expanded,
+  ...base
+}: PickerTileProps) {
+  return (
+    <button
+      type="button"
+      className={footprint({ wide: true, ...base, className: `tile--picker ${base.className ?? ''}` })}
+      onClick={onClick}
+      {...(expanded !== undefined ? { 'aria-expanded': expanded } : {})}
+      {...(base.title !== undefined ? { title: base.title } : {})}
+    >
+      <TileHead
+        icon={icon}
+        title={label}
+        value={value}
+        trailing={
+          <span className="tile__chev" aria-hidden="true">
+            ›
+          </span>
+        }
+      />
+      {dots != null && dots.length > 0 && (
+        <span className="tile__dots" aria-hidden="true">
+          {dots.map((d, i) => (
+            <span key={i} className="tile__dot" style={{ background: d }} />
+          ))}
+        </span>
+      )}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 7. Action tile
+// ---------------------------------------------------------------------------
+
+export interface ActionTileProps extends TileBaseProps {
+  icon: LucideIcon;
+  label: string;
+  value?: string;
+  onClick: () => void;
+  danger?: boolean;
+  disabled?: boolean;
+}
+
+export function ActionTile({
+  icon,
+  label,
+  value,
+  onClick,
+  danger = false,
+  disabled = false,
+  ...base
+}: ActionTileProps) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      className={footprint({
+        ...base,
+        className: `tile--action ${danger ? 'is-danger' : ''} ${base.className ?? ''}`,
+      })}
+      onClick={onClick}
+      {...(base.title !== undefined ? { title: base.title } : {})}
+    >
+      <TileHead icon={icon} title={label} value={value} />
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 8. Status tile (read-only)
+// ---------------------------------------------------------------------------
+
+export interface StatusTileProps extends TileBaseProps {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  meta?: string;
+}
+
+export function StatusTile({ icon, label, value, meta, ...base }: StatusTileProps) {
+  return (
+    <div
+      className={footprint({ wide: true, ...base, className: `tile--status ${base.className ?? ''}` })}
+      {...(base.title !== undefined ? { title: base.title } : {})}
+    >
+      <TileHead icon={icon} title={label} />
+      <div className="tile__body tile__body--status">
+        <span className="tile__metric">{value}</span>
+        {meta != null && <span className="tile__value">{meta}</span>}
+      </div>
+    </div>
+  );
+}
+
+/** Escape hatch for a control with no matching tile type (a colour field, a
+ *  bespoke row). Gets the tile chrome and footprint; owns its own body. */
+export interface CustomTileProps extends TileBaseProps {
+  icon?: LucideIcon;
+  chip?: ReactNode;
+  label: string;
+  value?: string;
+  children?: ReactNode;
+}
+
+export function CustomTile({ icon, chip, label, value, children, ...base }: CustomTileProps) {
+  return (
+    <div className={footprint(base)} {...(base.title !== undefined ? { title: base.title } : {})}>
+      <TileHead
+        {...(icon !== undefined ? { icon } : {})}
+        {...(chip !== undefined ? { chip } : {})}
+        title={label}
+        value={value}
+      />
+      {children != null && <div className="tile__body">{children}</div>}
+    </div>
+  );
+}

--- a/src/ui/tiles/Tile.tsx
+++ b/src/ui/tiles/Tile.tsx
@@ -104,14 +104,31 @@ interface TileBaseProps {
   /** Span two rows. */
   tall?: boolean;
   className?: string;
-  /** Native tooltip — where a row's hint text goes in the tile layout. */
+  /** Native tooltip — for detail that supports a choice already understood. */
   title?: string;
+  /**
+   * Visible help text inside the tile.
+   *
+   * Use this, not `title`, whenever the reader needs the text *to make* the
+   * choice rather than to confirm it — what three spellcheck modes actually do,
+   * when a setting takes effect at all. A tooltip is discoverable only by
+   * hovering, which rules it out on touch entirely, so anything load-bearing
+   * has to be on the tile. The hint lives INSIDE the tile: help floating beside
+   * a tile reads as belonging to the group, not the control.
+   */
+  hint?: string;
 }
 
 function footprint({ wide, tall, className = '' }: TileBaseProps): string {
   return ['tile', wide ? 'tile--w2' : '', tall ? 'tile--h2' : '', className]
     .filter(Boolean)
     .join(' ');
+}
+
+/** Visible in-tile help. Rendered last so it reads as a footnote to the control. */
+function TileHint({ hint }: { hint?: string | undefined }) {
+  if (hint == null) return null;
+  return <span className="tile__hint">{hint}</span>;
 }
 
 interface TileHeadProps {
@@ -191,6 +208,7 @@ export function ToggleTile({
       {...(base.title !== undefined ? { title: base.title } : {})}
     >
       <TileHead icon={icon} title={label} value={note ?? (checked ? onLabel : offLabel)} />
+      <TileHint hint={base.hint} />
     </button>
   );
 }
@@ -205,6 +223,13 @@ export interface SegmentedTileProps<T extends string> extends TileBaseProps {
   value: T;
   onValueChange: (value: T) => void;
   options: ReadonlyArray<SegmentedOption<T>>;
+  /**
+   * Accessible name for the group, when the visible title is too terse to stand
+   * alone. A tile title leans on its group header for context ("Base" under
+   * "Theme"), but that header is not programmatically associated — so a screen
+   * reader would just hear "Base". Defaults to `label`.
+   */
+  ariaLabel?: string;
 }
 
 /** Wraps the real `SegmentedControl`, so roving-tabindex + radiogroup semantics
@@ -215,6 +240,7 @@ export function SegmentedTile<T extends string>({
   value,
   onValueChange,
   options,
+  ariaLabel,
   ...base
 }: SegmentedTileProps<T>) {
   return (
@@ -222,12 +248,13 @@ export function SegmentedTile<T extends string>({
       <TileHead icon={icon} title={label} />
       <div className="tile__body">
         <SegmentedControl
-          ariaLabel={label}
+          ariaLabel={ariaLabel ?? label}
           value={value}
           onValueChange={onValueChange}
           options={options}
         />
       </div>
+      <TileHint hint={base.hint} />
     </div>
   );
 }
@@ -281,6 +308,7 @@ export function SliderTile({
           step={step}
         />
       </div>
+      <TileHint hint={base.hint} />
     </div>
   );
 }
@@ -396,7 +424,7 @@ export interface SwatchTileProps extends TileBaseProps {
   /** No explicit value set — the theme engine derives it. */
   derived?: boolean;
   /** Display value under the title (a hex, usually). */
-  value?: string;
+  value?: string | undefined;
   onClick?: () => void;
 }
 
@@ -487,7 +515,7 @@ export function PickerTile({
 export interface ActionTileProps extends TileBaseProps {
   icon: LucideIcon;
   label: string;
-  value?: string;
+  value?: string | undefined;
   onClick: () => void;
   danger?: boolean;
   disabled?: boolean;
@@ -514,6 +542,7 @@ export function ActionTile({
       {...(base.title !== undefined ? { title: base.title } : {})}
     >
       <TileHead icon={icon} title={label} value={value} />
+      <TileHint hint={base.hint} />
     </button>
   );
 }
@@ -526,7 +555,7 @@ export interface StatusTileProps extends TileBaseProps {
   icon: LucideIcon;
   label: string;
   value: string;
-  meta?: string;
+  meta?: string | undefined;
 }
 
 export function StatusTile({ icon, label, value, meta, ...base }: StatusTileProps) {
@@ -540,30 +569,42 @@ export function StatusTile({ icon, label, value, meta, ...base }: StatusTileProp
         <span className="tile__metric">{value}</span>
         {meta != null && <span className="tile__value">{meta}</span>}
       </div>
+      <TileHint hint={base.hint} />
     </div>
   );
 }
 
-/** Escape hatch for a control with no matching tile type (a colour field, a
- *  bespoke row). Gets the tile chrome and footprint; owns its own body. */
+/**
+ * Escape hatch for a control with no matching tile type — a colour field, a
+ * bespoke preset row. Gets the tile chrome and mosaic footprint; owns its body.
+ *
+ * `label` is optional: some hosted controls (ColorField) already render their
+ * own label, hint and warning, and duplicating it in the tile head would say
+ * everything twice. Omitting it gives a container-only tile.
+ */
 export interface CustomTileProps extends TileBaseProps {
   icon?: LucideIcon;
   chip?: ReactNode;
-  label: string;
-  value?: string;
+  label?: string | undefined;
+  value?: string | undefined;
   children?: ReactNode;
 }
 
 export function CustomTile({ icon, chip, label, value, children, ...base }: CustomTileProps) {
   return (
     <div className={footprint(base)} {...(base.title !== undefined ? { title: base.title } : {})}>
-      <TileHead
-        {...(icon !== undefined ? { icon } : {})}
-        {...(chip !== undefined ? { chip } : {})}
-        title={label}
-        value={value}
-      />
-      {children != null && <div className="tile__body">{children}</div>}
+      {label != null && (
+        <TileHead
+          {...(icon !== undefined ? { icon } : {})}
+          {...(chip !== undefined ? { chip } : {})}
+          title={label}
+          value={value}
+        />
+      )}
+      {children != null && (
+        <div className={label != null ? 'tile__body' : 'tile__body tile__body--only'}>{children}</div>
+      )}
+      <TileHint hint={base.hint} />
     </div>
   );
 }

--- a/src/ui/tiles/tiles.css
+++ b/src/ui/tiles/tiles.css
@@ -1,0 +1,526 @@
+/* ==========================================================================
+   Tile system (JP-253) — the mosaic engine and the eight tile types.
+   Shared by the layout menu and Settings. Surface tokens come from the glass
+   block in index.css; nothing here reaches for a raw brand ramp.
+   ========================================================================== */
+
+/* --- The mosaic ----------------------------------------------------------- */
+.tile-grid {
+  /* Overridden per-instance by TileGrid's inline style. */
+  --tile-min: 150px;
+  --tile-row: 86px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(var(--tile-min), 100%), 1fr));
+  /* A FLOOR, not a fixed height — see the note in Tile.tsx. A constant row
+     silently clips segmented controls once density or --ui-scale moves. */
+  grid-auto-rows: minmax(var(--tile-row), auto);
+  grid-auto-flow: row dense;
+  gap: var(--space-2);
+}
+
+/* --- Group ---------------------------------------------------------------- */
+.tile-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.tile-group__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-1);
+}
+
+.tile-group__icon {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--text-muted);
+}
+
+.tile-group__title {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.tile-group__rule {
+  flex: 1 1 auto;
+  height: 1px;
+  background: var(--border-color-light);
+}
+
+/* --- Tile base ------------------------------------------------------------ */
+.tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5);
+  padding: calc(var(--space-2) + var(--space-0-5)) var(--space-3);
+  background: var(--glass-tile);
+  /* NO backdrop-filter here, deliberately. Each backdrop-filter element costs
+     its own backdrop read-back + blur pass, and a nested one re-blurs its
+     already-blurred parent. The sheet blurs once; tiles are plain translucent
+     fills over it — visually identical, ~1/20th the cost. `tiles.test.tsx`
+     pins this so it cannot creep back in. */
+  border: 1px solid var(--glass-tile-border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-tile), var(--glass-highlight-soft);
+  color: var(--text-primary);
+  text-align: left;
+  font: inherit;
+  overflow: hidden;
+  /* Paint isolation per tile: a tile repainting on hover or toggle cannot dirty
+     its neighbours. (This does NOT shrink the scrollable overflow rectangle —
+     that is handled by keeping descendants inside the box; see the bloom.) */
+  contain: paint;
+  transition:
+    background-color var(--dur-med) var(--ease-out),
+    border-color var(--dur-med) var(--ease-out),
+    box-shadow var(--dur-med) var(--ease-out),
+    transform var(--dur-fast) var(--ease-out);
+}
+
+button.tile {
+  appearance: none;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+button.tile:hover:not(:disabled) {
+  background: var(--glass-tile-hover);
+  border-color: var(--glass-tile-border);
+  box-shadow: var(--shadow-tile-hover), var(--glass-highlight);
+  transform: translateY(-1px);
+}
+
+button.tile:active:not(:disabled) {
+  transform: translateY(0) scale(0.978);
+  transition-duration: 0.06s;
+}
+
+button.tile:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.tile:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* A flex/grid item's default min-size is `auto` — "never shrink below my
+   content" — which is how a segmented control with long labels pushes out of
+   its tile. Every nesting level has to opt out, not just the innermost. */
+.tile > * {
+  min-width: 0;
+}
+
+.tile__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.tile__chip {
+  flex: none;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-lg);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color-light);
+  box-shadow: var(--shadow-sm);
+  transition:
+    background var(--dur-med) var(--ease-out),
+    color var(--dur-med) var(--ease-out),
+    border-color var(--dur-med) var(--ease-out),
+    transform var(--dur-slow) var(--ease-spring);
+}
+
+.tile__text {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+/* Titles wrap to two lines rather than truncating — a settings label reading
+   "Mobile prev…" is a label that failed, and the tile has the vertical room. */
+.tile__title {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.2;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}
+
+.tile__value {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color var(--dur-med) var(--ease-out);
+}
+
+.tile__body {
+  margin-top: auto;
+  min-width: 0;
+}
+
+/* The Slider primitive is a fixed 160px; in a tile it should fill the row. */
+.tile__body--slider .ds-slider {
+  width: 100%;
+}
+
+.tile__body--status {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.tile__metric {
+  margin-left: auto;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+
+.tile__body--status .tile__metric {
+  margin-left: 0;
+}
+
+.tile__badge {
+  align-self: flex-start;
+  margin-left: auto;
+  flex: none;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-active);
+  color: var(--text-muted);
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.03em;
+}
+
+.tile__chev {
+  margin-left: auto;
+  flex: none;
+  color: var(--text-faint);
+  font-size: var(--font-size-lg);
+  line-height: 1;
+}
+
+.tile--w2 {
+  grid-column: span 2;
+}
+
+.tile--h2 {
+  grid-row: span 2;
+}
+
+/* --- 1. Toggle tile -------------------------------------------------------
+   Switching on is one gesture with three parts: a tinted bloom wipes out from
+   behind the icon chip, the chip fills with the accent gradient and springs,
+   and the state word recolours.
+   ------------------------------------------------------------------------- */
+.tile--toggle {
+  justify-content: center;
+  isolation: isolate;
+}
+
+.tile--toggle::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: var(--color-primary-light);
+  /* The wipe is a clip-path, NOT a scaled circle. A transformed or oversized
+     absolutely-positioned child extends the tile's scrollable overflow
+     rectangle — and `overflow: hidden` hides the scrollbar without removing the
+     scroll, so a focus event can shunt tile content sideways (measured at
+     195x102px on the prototype, and only while the toggle was on). clip-path is
+     a paint-time clip with no layout contribution: the element never leaves its
+     own box. Pinned by tiles.test.tsx. */
+  clip-path: circle(0% at calc(var(--space-3) + 15px) calc(var(--space-2) + 15px));
+  opacity: 0;
+  transition:
+    clip-path var(--dur-slow) var(--ease-out),
+    opacity var(--dur-med) var(--ease-out);
+  pointer-events: none;
+}
+
+.tile--toggle[aria-checked='true']::before {
+  clip-path: circle(140% at calc(var(--space-3) + 15px) calc(var(--space-2) + 15px));
+  opacity: 1;
+}
+
+.tile--toggle[aria-checked='true'] {
+  border-color: var(--color-primary-alpha);
+  box-shadow: var(--shadow-tile-hover), var(--glass-highlight);
+}
+
+.tile--toggle[aria-checked='true'] .tile__chip {
+  background: var(--grad-primary);
+  color: var(--color-on-primary);
+  border-color: transparent;
+  transform: scale(1.08);
+  box-shadow: var(--shadow-md);
+}
+
+.tile--toggle[aria-checked='true'] .tile__value {
+  color: var(--color-primary);
+  font-weight: var(--font-weight-medium);
+}
+
+/* Compact variant — a row, not a card. Used inside popovers. */
+.tile--chip {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) calc(var(--space-2) + var(--space-0-5));
+  border-radius: var(--radius-lg);
+}
+
+.tile--chip .tile__chip {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-md);
+}
+
+.tile--chip .tile__title {
+  font-size: var(--font-size-sm);
+}
+
+/* --- 3. Slider tile ------------------------------------------------------- */
+.tile--picker {
+  justify-content: center;
+}
+
+.tile__dots {
+  display: flex;
+  gap: 4px;
+  margin-top: auto;
+}
+
+.tile__dot {
+  width: 14px;
+  height: 14px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border-color);
+}
+
+/* --- 4. Fill tile --------------------------------------------------------- */
+.tile--fill {
+  --fill-axis: y;
+  padding: 0;
+  cursor: ns-resize;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.tile--fill .fill__level {
+  position: absolute;
+  inset: auto 0 0 0;
+  height: var(--level, 50%);
+  background: var(--grad-fill);
+  transition: height 0.06s linear;
+  pointer-events: none;
+}
+
+/* A bright meniscus at the top of the fill — the liquid edge catching light. */
+.tile--fill .fill__level::after {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.45);
+}
+
+[data-glass='off'] .tile--fill .fill__level::after {
+  display: none;
+}
+
+.tile--fill .fill__content {
+  position: relative;
+  z-index: 1;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: var(--space-3);
+  pointer-events: none;
+}
+
+.tile--fill .fill__icon {
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-lg);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color-light);
+  box-shadow: var(--shadow-sm);
+}
+
+.tile--fill .fill__foot {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.tile--fill .fill__metric {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.tile--fill .fill__label {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  line-height: 1.2;
+}
+
+/* --- 5. Swatch tile ------------------------------------------------------- */
+.tile--swatch {
+  justify-content: center;
+}
+
+/* Inset hairline so a near-white swatch still reads as a swatch on paper. */
+.tile--swatch .tile__chip {
+  box-shadow: inset 0 0 0 1px rgba(128, 128, 128, 0.28), var(--shadow-sm);
+  border-color: transparent;
+}
+
+/* --- 7. Action tile ------------------------------------------------------- */
+.tile--action {
+  justify-content: center;
+  border: 1px dashed var(--border-color-input);
+  background: transparent;
+}
+
+button.tile--action:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-style: solid;
+}
+
+.tile--action.is-danger .tile__chip {
+  color: var(--danger-text);
+}
+
+button.tile--action.is-danger:hover:not(:disabled) {
+  background: var(--danger-bg);
+  border-color: var(--danger);
+}
+
+/* --- 8. Status tile ------------------------------------------------------- */
+.tile--status {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  box-shadow: none;
+}
+
+/* ==========================================================================
+   REDUCED MOTION
+   `adaptiveBudget` is the sole authority over `data-reduced-motion` (Settings →
+   Motion + the OS setting), so the tile language answers to that attribute
+   rather than declaring its own media query. State still changes instantly and
+   legibly — it just stops springing.
+   ========================================================================== */
+:root[data-reduced-motion='true'] .tile,
+:root[data-reduced-motion='true'] .tile::before,
+:root[data-reduced-motion='true'] .tile__chip,
+:root[data-reduced-motion='true'] .tile__value,
+:root[data-reduced-motion='true'] .fill__level {
+  transition-duration: 0.01ms;
+}
+
+:root[data-reduced-motion='true'] button.tile:hover:not(:disabled) {
+  transform: none;
+}
+
+:root[data-reduced-motion='true'] .tile--toggle[aria-checked='true'] .tile__chip {
+  transform: none;
+}
+
+/* ==========================================================================
+   CONTAINER QUERIES — last in the file on purpose.
+   A container query adds NO specificity, so these rules only win by source
+   order. Moving this block above anything it overrides silently breaks it.
+   The container itself is established by the consuming surface (the settings
+   sheet, the layout popover) with `container-type: inline-size`.
+   ========================================================================== */
+@container (max-width: 560px) {
+  .tile-grid {
+    --tile-min: 138px;
+  }
+}
+
+@container (max-width: 330px) {
+  /* Only one column fits. A 2-wide tile can no longer span, and a tall fill
+     slider would eat the viewport — so it rotates into a horizontal fill bar
+     rather than collapsing into an unusable square. */
+  .tile--w2 {
+    grid-column: span 1;
+  }
+
+  .tile--h2 {
+    grid-row: span 1;
+  }
+
+  .tile--fill {
+    --fill-axis: x;
+    cursor: ew-resize;
+  }
+
+  .tile--fill .fill__level {
+    inset: 0 auto 0 0;
+    height: auto;
+    width: var(--level, 50%);
+    transition: width 0.06s linear;
+  }
+
+  .tile--fill .fill__content {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-2);
+    padding: calc(var(--space-2) + var(--space-0-5)) var(--space-3);
+  }
+
+  .tile--fill .fill__foot {
+    flex-direction: row;
+    align-items: baseline;
+    gap: var(--space-2);
+    margin-left: auto;
+  }
+
+  .tile--fill .fill__label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}

--- a/src/ui/tiles/tiles.css
+++ b/src/ui/tiles/tiles.css
@@ -62,6 +62,18 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  /* Top-aligned, and uniformly so. Grid rows stretch every tile to the tallest
+     in the row, which makes any other choice ragged:
+       - `margin-top: auto` on the body (the first attempt) pushed the control
+         to the tile's bottom edge, opening a gap that grew with whatever else
+         shared the row — worst on Caret style, whose two-option control sits
+         beside taller neighbours.
+       - Centring the head+control group (the second attempt) then split the
+         difference: tiles carrying a hint top-aligned while tiles without one
+         centred, so heads in the same row started at different heights.
+     Every tile's head starting at the same y is what makes a mosaic read as a
+     grid; trailing space inside a stretched tile is invisible by comparison. */
+  justify-content: flex-start;
   gap: var(--space-1-5);
   padding: calc(var(--space-2) + var(--space-0-5)) var(--space-3);
   background: var(--glass-tile);
@@ -180,7 +192,6 @@ button.tile:disabled {
 }
 
 .tile__body {
-  margin-top: auto;
   min-width: 0;
 }
 
@@ -206,6 +217,20 @@ button.tile:disabled {
 
 .tile__body--status .tile__metric {
   margin-left: 0;
+}
+
+/* In-tile help. Sits inside the tile, below the control, so it reads as part of
+   that control rather than as commentary on the group. */
+.tile__hint {
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-snug);
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.tile__hint strong {
+  color: var(--text-secondary);
+  font-weight: var(--font-weight-semibold);
 }
 
 .tile__badge {
@@ -243,7 +268,6 @@ button.tile:disabled {
    and the state word recolours.
    ------------------------------------------------------------------------- */
 .tile--toggle {
-  justify-content: center;
   isolation: isolate;
 }
 
@@ -311,10 +335,6 @@ button.tile:disabled {
 }
 
 /* --- 3. Slider tile ------------------------------------------------------- */
-.tile--picker {
-  justify-content: center;
-}
-
 .tile__dots {
   display: flex;
   gap: 4px;
@@ -406,10 +426,6 @@ button.tile:disabled {
 }
 
 /* --- 5. Swatch tile ------------------------------------------------------- */
-.tile--swatch {
-  justify-content: center;
-}
-
 /* Inset hairline so a near-white swatch still reads as a swatch on paper. */
 .tile--swatch .tile__chip {
   box-shadow: inset 0 0 0 1px rgba(128, 128, 128, 0.28), var(--shadow-sm);
@@ -418,7 +434,6 @@ button.tile:disabled {
 
 /* --- 7. Action tile ------------------------------------------------------- */
 .tile--action {
-  justify-content: center;
   border: 1px dashed var(--border-color-input);
   background: transparent;
 }

--- a/src/ui/tiles/tiles.test.tsx
+++ b/src/ui/tiles/tiles.test.tsx
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Maximize, Rows3, Smartphone } from 'lucide-react';
+import { FillTile, SegmentedTile, ToggleTile } from './Tile';
+
+// Vite's test transform rewrites `import.meta.url` to a non-file scheme, so
+// resolve from the project root (vitest's cwd) instead.
+const readSrc = (rel: string) => readFileSync(resolve(process.cwd(), rel), 'utf8');
+const CSS = readSrc('src/ui/tiles/tiles.css');
+/** Declarations only. The comments in this file discuss the very properties the
+ *  guards below forbid, so matching raw source would fail on the prose. */
+const CSS_DECLS = CSS.replace(/\/\*[\s\S]*?\*\//g, '');
+
+/** The declaration block for a selector, so an assertion can't be satisfied by
+ *  an unrelated rule elsewhere in the file. */
+function ruleBody(selector: string): string {
+  const at = CSS_DECLS.indexOf(selector);
+  if (at === -1) throw new Error(`selector not found in tiles.css: ${selector}`);
+  const open = CSS_DECLS.indexOf('{', at);
+  const close = CSS_DECLS.indexOf('}', open);
+  return CSS_DECLS.slice(open + 1, close);
+}
+
+/**
+ * CSS contract.
+ *
+ * These are deliberately **source** assertions, not layout assertions. All three
+ * defects below were found by measuring a real browser, and jsdom has no layout
+ * engine — `scrollWidth`, `clientWidth` and resolved geometry are all stubbed to
+ * 0, so a test asserting "the control is not clipped" here would pass whether or
+ * not it actually was. Guarding the CSS decision that caused each defect is the
+ * honest thing a unit test can do; the geometry itself is re-checked in the
+ * browser (see the verification steps on the PR).
+ */
+describe('tiles.css contract', () => {
+  it('sizes grid rows with a floor, not a fixed height', () => {
+    // A constant row height clipped every segmented control by 14px: chip (30) +
+    // gap + control (30) + padding (20) exceeds it, and all of those move again
+    // with --density-mult and --ui-scale.
+    const grid = ruleBody('.tile-grid {');
+    expect(grid).toMatch(/grid-auto-rows:\s*minmax\(/);
+    expect(grid).not.toMatch(/grid-auto-rows:\s*var\(--tile-row\)\s*;/);
+  });
+
+  it('never puts backdrop-filter on a tile', () => {
+    // backdrop-filter costs a backdrop read-back + blur pass per element, and a
+    // nested one re-blurs its already-blurred parent. Measured: 2 blur surfaces
+    // = 7.15ms/frame, 32 = 9.46ms/frame, for no visible difference. The sheet
+    // blurs once; tiles are plain translucent fills over it.
+    expect(CSS_DECLS).not.toMatch(/backdrop-filter/);
+  });
+
+  it('wipes the toggle bloom with clip-path, never a transform', () => {
+    // A transformed/oversized absolutely-positioned child extends the tile's
+    // scrollable overflow rectangle. `overflow: hidden` hides the scrollbar but
+    // does not remove the scroll — setting scrollLeft really did shunt tile
+    // content 195px sideways, and only while the toggle was on.
+    const bloom = ruleBody('.tile--toggle::before {');
+    expect(bloom).toMatch(/clip-path:\s*circle\(/);
+    expect(bloom).not.toMatch(/transform:/);
+  });
+
+  it('keeps the container queries below the rules they override', () => {
+    // Container queries carry no specificity bump, so they win by source order
+    // alone. Hoisting this block above the base rules silently breaks reflow.
+    expect(CSS_DECLS.indexOf('@container')).toBeGreaterThan(CSS_DECLS.indexOf('.tile--w2 {'));
+    expect(CSS_DECLS.indexOf('@container')).toBeGreaterThan(CSS_DECLS.indexOf('.tile--fill {'));
+  });
+});
+
+describe('ToggleTile', () => {
+  it('exposes switch semantics rather than a plain button', () => {
+    render(
+      <ToggleTile icon={Smartphone} label="Mobile preview" checked onCheckedChange={() => {}} />
+    );
+    const el = screen.getByRole('switch', { name: 'Mobile preview' });
+    expect(el.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('toggles to the opposite of its current value', () => {
+    const onCheckedChange = vi.fn();
+    render(
+      <ToggleTile
+        icon={Smartphone}
+        label="Mobile preview"
+        checked={false}
+        onCheckedChange={onCheckedChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('switch', { name: 'Mobile preview' }));
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('shows the state word, and a note when one is given', () => {
+    const { rerender } = render(
+      <ToggleTile icon={Smartphone} label="Mobile preview" checked onCheckedChange={() => {}} />
+    );
+    expect(screen.getByText('On')).toBeTruthy();
+
+    rerender(
+      <ToggleTile
+        icon={Smartphone}
+        label="Properties"
+        checked={false}
+        onCheckedChange={() => {}}
+        note="on selection"
+      />
+    );
+    expect(screen.getByText('on selection')).toBeTruthy();
+  });
+
+  it('does not fire when disabled', () => {
+    const onCheckedChange = vi.fn();
+    render(
+      <ToggleTile
+        icon={Smartphone}
+        label="Properties"
+        checked={false}
+        onCheckedChange={onCheckedChange}
+        disabled
+      />
+    );
+    fireEvent.click(screen.getByRole('switch', { name: 'Properties' }));
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('SegmentedTile', () => {
+  const OPTIONS = [
+    { value: 'compact', label: 'Compact' },
+    { value: 'normal', label: 'Normal' },
+    { value: 'spacious', label: 'Spacious' },
+  ] as const;
+
+  it('renders the real SegmentedControl, keeping radiogroup semantics', () => {
+    const onValueChange = vi.fn();
+    render(
+      <SegmentedTile
+        icon={Rows3}
+        label="Density"
+        value="normal"
+        onValueChange={onValueChange}
+        options={OPTIONS}
+      />
+    );
+    expect(screen.getByRole('radio', { name: 'Normal' }).getAttribute('aria-checked')).toBe('true');
+    fireEvent.click(screen.getByRole('radio', { name: 'Spacious' }));
+    expect(onValueChange).toHaveBeenCalledWith('spacious');
+  });
+});
+
+describe('FillTile', () => {
+  const props = {
+    icon: Maximize,
+    label: 'Interface size',
+    min: 75,
+    max: 150,
+    step: 5,
+  };
+
+  it('reports slider semantics with its current value', () => {
+    render(<FillTile {...props} value={100} onValueChange={() => {}} />);
+    const el = screen.getByRole('slider', { name: 'Interface size' });
+    expect(el.getAttribute('aria-valuenow')).toBe('100');
+    expect(el.getAttribute('aria-valuemin')).toBe('75');
+    expect(el.getAttribute('aria-valuemax')).toBe('150');
+  });
+
+  it('steps with the arrow keys — the drag surface alone is not keyboard-reachable', () => {
+    const onValueChange = vi.fn();
+    render(<FillTile {...props} value={100} onValueChange={onValueChange} />);
+    const el = screen.getByRole('slider', { name: 'Interface size' });
+
+    fireEvent.keyDown(el, { key: 'ArrowUp' });
+    expect(onValueChange).toHaveBeenLastCalledWith(105);
+
+    fireEvent.keyDown(el, { key: 'ArrowDown' });
+    expect(onValueChange).toHaveBeenLastCalledWith(95);
+  });
+
+  it('clamps at both ends rather than running past them', () => {
+    const onValueChange = vi.fn();
+    const { rerender } = render(<FillTile {...props} value={150} onValueChange={onValueChange} />);
+    fireEvent.keyDown(screen.getByRole('slider'), { key: 'ArrowUp' });
+    expect(onValueChange).toHaveBeenLastCalledWith(150);
+
+    rerender(<FillTile {...props} value={75} onValueChange={onValueChange} />);
+    fireEvent.keyDown(screen.getByRole('slider'), { key: 'ArrowDown' });
+    expect(onValueChange).toHaveBeenLastCalledWith(75);
+  });
+
+  it('jumps to the ends with Home and End', () => {
+    const onValueChange = vi.fn();
+    render(<FillTile {...props} value={100} onValueChange={onValueChange} />);
+    const el = screen.getByRole('slider');
+
+    fireEvent.keyDown(el, { key: 'Home' });
+    expect(onValueChange).toHaveBeenLastCalledWith(75);
+
+    fireEvent.keyDown(el, { key: 'End' });
+    expect(onValueChange).toHaveBeenLastCalledWith(150);
+  });
+});
+
+describe('glass opt-out', () => {
+  it('resolves every glass token back to an opaque value', () => {
+    // The Appearance toggle is one attribute on <html>; there must be no second
+    // styling path for components to drift against.
+    const indexCss = readSrc('src/index.css');
+    const off = indexCss.slice(indexCss.indexOf("[data-glass='off']"));
+    const block = off.slice(0, off.indexOf('}'));
+    for (const token of [
+      '--glass-surface',
+      '--glass-border',
+      '--glass-tile',
+      '--glass-tile-hover',
+      '--glass-tile-border',
+      '--glass-highlight',
+      '--shadow-float',
+      '--shadow-tile',
+      '--grad-primary',
+      '--grad-fill',
+    ]) {
+      expect(block).toContain(`${token}:`);
+    }
+    expect(block).toMatch(/--glass-blur:\s*0px/);
+  });
+});

--- a/src/ui/tiles/tiles.test.tsx
+++ b/src/ui/tiles/tiles.test.tsx
@@ -62,6 +62,16 @@ describe('tiles.css contract', () => {
     expect(bloom).not.toMatch(/transform:/);
   });
 
+  it('top-aligns tile content instead of centring or bottom-pushing it', () => {
+    // Grid rows stretch every tile to the tallest in the row, so anything but a
+    // uniform top alignment goes ragged: `margin-top: auto` pushed controls to
+    // the tile's bottom edge, and centring split heads to different heights
+    // depending on whether a tile carried a hint. Reported as "weird spacing
+    // anomalies", worst on Caret style.
+    expect(ruleBody('.tile {')).toMatch(/justify-content:\s*flex-start/);
+    expect(ruleBody('.tile__body {')).not.toMatch(/margin-top:\s*auto/);
+  });
+
   it('keeps the container queries below the rules they override', () => {
     // Container queries carry no specificity bump, so they win by source order
     // alone. Hoisting this block above the base rules silently breaks reflow.


### PR DESCRIPTION
Introduces a shared tile vocabulary and rebuilds two surfaces on it, so the layout menu and Settings read as one system rather than two surfaces that happen to share a palette.

Closes the reported layout-menu overflow, and converts four of five Settings tabs.

## The overflow bug

The layout menu was a 320px `position: absolute; right: 0` panel inside the toolbar, with no viewport clamp and no `max-height`. The compact variant that would have saved it was gated on `mobileActive`, which requires a **coarse pointer** — so a narrowed *desktop* window never qualified and the panel simply ran off-screen.

It is now portalled to the body and placed by `resolveMenuPlacement`, a pure helper beside the existing clamps in `floatingPosition.ts`: it shrinks on a narrow viewport, caps its height on a short one so it scrolls rather than truncating, and flips above the trigger when below is cramped and above is roomier. Sizing keys off `useBreakpoint().band`; the coarse-pointer signal is left to govern hit-target size only — the split settled in JP-486.

`ToolbarDropdown` was not reused: it clamps horizontally but never vertically, and owns its own trigger markup and click semantics, which would mean fighting it for hover-open and the menu ARIA roles.

## Settings

A full-bleed glass sheet replaces the 850×620 dialog, which gave the mosaic three columns and a scrollbar. Content is held to a 1180px column — full-bleed is about the surface, not about stretching controls across a 27" monitor. Appearance's thirteen one-and-two-row groups collapse to five. General, Style Profiles and About also converted; **Backup & Restore stays row-based** — it is an action/list surface rather than a control grid, and is the follow-up.

Help text renders **inside** its tile. A tooltip is reachable only by hovering, which rules it out on touch.

The sidebar's per-position icon colours are gone: hardcoded Tailwind hues (`#8b5cf6`, `#10b981`, `#ec4899`, `#06b6d4`) with drop-shadow glows on a warm-paper/navy brand, keyed to `nth-child` positions for a tab list that no longer exists — the comments named Documents / Collaboration / Storage / Shape Libraries, none of them tabs since JP-218, so they had silently drifted onto the wrong entries.

## Defects found by measuring, each now guarded

Three were invisible until measured, and are pinned in `tiles.test.tsx` as **CSS-contract** assertions rather than layout assertions — jsdom has no layout engine, so a geometry test there would pass whether or not the defect was present.

1. A fixed `grid-auto-rows` clipped every segmented control by 14px. Chip + gap + control + padding never fits a constant row, and all of it moves again with `--density-mult` and `--ui-scale`.
2. A scaled pseudo-element extends a tile's **scrollable overflow rectangle** even under `overflow: hidden` — setting `scrollLeft` really did shunt tile content 195px sideways, and only while the toggle was on. The bloom is a `clip-path`, which has no layout contribution.
3. `backdrop-filter` cost scales with the **count** of blur surfaces, not the radius: 7.15ms/frame at 2 surfaces vs 9.46ms at 32 (blur on every tile), for no visible difference. One blur per floating panel; tiles are plain translucent fills.

Two more surfaced while wiring the sheet, both mine:

- `container-type: inline-size` on a flex item with an auto inline margin collapses to **0px wide** — auto margins disable cross-axis stretch, and a query container contributes nothing to intrinsic size.
- A dark-mode `.settings-modal-content` rule lost its `[data-theme]` prefix mid-edit and was painting an opaque fill over the glass in *both* themes.

## Glass is an opt-out

`appearancePrefs.glass`, default on, uiPreferences v13→14 with a migration. `[data-glass="off"]` resolves every glass token back to today's opaque surfaces, so the escape hatch is one attribute on `<html>` and there is no second styling path to drift. It exists because the Tauri shell runs WebKitGTK, where `backdrop-filter` is historically weaker than the Chromium numbers above.

## Verification

- `bun run typecheck` clean; **3,535 tests pass** (296 files), including 15 new tile tests and 8 new placement tests.
- Live in the browser on the real dev server:
  - Layout menu at 1280/480/320px and at a 400px-tall viewport — fully on screen at every size, scrolling rather than truncating. Measured, not eyeballed.
  - Settings swept for `scrollWidth − clientWidth` across every descendant: **0 overflowing elements and 0 ragged rows across all nine density × interface-size combinations**.

**Not verified:** WebKitGTK. The frame numbers above are Chromium. If the Tauri shell performs badly, the Appearance toggle is the mitigation and the default can flip without further work.

## Docs

`docs-site/guide/settings.md` rewritten — it still documented Documents, Storage and Shape Libraries tabs (moved out by JP-218) and a Default Connector Type setting that no longer exists. `layout-modes.md` gains the View menu.

Assisted-by: Opus 5