### PR TITLE
JP-493: a blank credential is not an Authorization header

### DIFF
--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -2693,6 +2693,31 @@ pub(crate) fn ingest_url_ok(url: &reqwest::Url, allow: &[String]) -> bool {
     }
 }
 
+/// The `Authorization` value to forward to the blob source, if any.
+///
+/// An empty or whitespace-only value is not a credential, and forwarding it as a
+/// header is actively harmful rather than merely useless. A presigned URL carries
+/// its authorization in the query string, and S3 rejects a request that *also*
+/// presents an `Authorization` header:
+///
+/// ```text
+/// 400 InvalidArgument — Only one auth mechanism allowed; only the X-Amz-Algorithm
+/// query parameter, Signature query string parameter or the Authorization header
+/// should be specified
+/// ```
+///
+/// A caller with a presigned URL correctly sends no credential — but the wire
+/// field is a plain `String`, so "none" arrives as `""`, and this function's
+/// caller wrapped it in `Some(...)` regardless. Every ingest of a presigned URL
+/// therefore failed from the day it shipped (JP-493).
+///
+/// Non-empty values pass through untouched: sources that are *not* presigned
+/// genuinely need the header, so this must stay a blank filter and never become
+/// an unconditional drop.
+fn ingest_auth_header(authorization: Option<&str>) -> Option<&str> {
+    authorization.filter(|s| !s.trim().is_empty())
+}
+
 /// Identity of a blob persisted by the shared write core (JP-430 E3): the
 /// content hash, authoritative size, and the mime recorded in the index.
 pub(crate) struct StoredBlob {
@@ -2816,8 +2841,12 @@ pub(crate) async fn ingest_blob_from_url(
         return Err(BlobWriteError::UrlNotAllowed);
     }
 
+    // Captured before `url` is moved into the request, so the rejection log below
+    // can name the host without re-parsing.
+    let host_for_log = url.host_str().unwrap_or("?").to_string();
+
     let mut req = http.get(url);
-    if let Some(auth) = authorization {
+    if let Some(auth) = ingest_auth_header(authorization) {
         req = req.header(reqwest::header::AUTHORIZATION, auth);
     }
     let mut resp = match req.send().await {
@@ -2828,6 +2857,15 @@ pub(crate) async fn ingest_blob_from_url(
         }
     };
     if !resp.status().is_success() {
+        // Log parity with the transport-error arm above, which had it from the
+        // start. An upstream *rejection* left no trace at all: the 502 showed up
+        // in metrics with no matching line, so the natural read was "the proxy is
+        // broken" while S3 was in fact answering 400 every time (JP-493).
+        log::info!(
+            "ingest source rejected for ws {}: {host_for_log} returned {}",
+            ws.as_str(),
+            resp.status()
+        );
         return Err(BlobWriteError::Fetch(format!(
             "source returned {}",
             resp.status()
@@ -3012,6 +3050,23 @@ mod tests {
         assert!(!ingest_host_allowed("notexample.net", &allow)); // not a dot-boundary
         assert!(!ingest_host_allowed("", &allow));
         assert!(!ingest_host_allowed("api.example.com", &[])); // empty allowlist = nothing
+    }
+
+    #[test]
+    fn ingest_auth_header_treats_blank_as_absent() {
+        // The whole point: a blank credential must not become a header. Sending
+        // one to a presigned URL is a 400 from S3, not a no-op, so "harmless
+        // extra header" is exactly the wrong intuition here (JP-493).
+        assert_eq!(ingest_auth_header(None), None);
+        assert_eq!(ingest_auth_header(Some("")), None);
+        assert_eq!(ingest_auth_header(Some("   ")), None);
+        assert_eq!(ingest_auth_header(Some("\t\n")), None);
+
+        // ...and a real credential still goes through untouched, including its
+        // surrounding whitespace: this filters blank values, it does not trim
+        // values it keeps. Sources that are not presigned depend on this.
+        assert_eq!(ingest_auth_header(Some("Bearer abc")), Some("Bearer abc"));
+        assert_eq!(ingest_auth_header(Some(" Bearer abc ")), Some(" Bearer abc "));
     }
 
     #[test]


### PR DESCRIPTION
Found running the first real connect→import→image round-trip. Ingest of a **presigned URL has never worked**, in any environment.

## The bug

The ingest wire field is a plain `String`, so a caller with a presigned URL — which carries its authorization in the query string and needs no credential — expresses that as `""`. `blob_ingest_from_url_handler` wraps it in `Some(..)` unconditionally, and `ingest_blob_from_url` sets the header for any `Some`. The relay therefore sent an empty `Authorization:` on every such fetch.

S3 does not ignore it:

```
400 InvalidArgument — Only one auth mechanism allowed; only the X-Amz-Algorithm
query parameter, Signature query string parameter or the Authorization header
should be specified
```

Verified against a real presigned URL rather than inferred:

```
WITH empty Authorization (today)  → HTTP 400  InvalidArgument: Only one auth mechanism allowed…
WITHOUT Authorization             → HTTP 200  (image/png)
```

## The fix

Filter blank values at the point of use, so both the REST handler and the MCP file preflight are covered by one change.

It is a **blank filter, not a trim**: a source that is not presigned genuinely needs the header, and its value — surrounding whitespace included — passes through untouched. The test pins both directions, because the tempting "just drop it" simplification would break every non-presigned source.

## Also: the upstream-rejection branch was silent

The transport-error arm has logged since it was written. A non-2xx *response* returned `Fetch("source returned …")` with no log at all, so the failure surfaced as a 502 in metrics with **zero** matching log lines — confirmed operationally against staging. That silence is what made this read as a broken proxy rather than a rejected request, and it cost most of the investigation. Now logged with the host and status, at parity with the arm beside it.

## Layer discipline

`blob_ingest_from_url_handler`'s own docs say the relay has no knowledge of any specific integration. The rule is therefore stated in terms of presigned URLs; no provider is named anywhere in the diff.

## Verification

- 801 lib tests + every integration suite pass (`cargo test --locked`, the CI gate).
- `cargo check --all-targets` clean.
- Clippy reports 24 pre-existing findings across 8 files (`unnecessary_map_or`, `derivable_impls`, …) from a newer toolchain than CI's. None are in this change; CI does not run clippy.

## Rollout note

This is the relay, so it needs an image build and a pin move to reach an environment: `master` → master→staging PR → `:edge` → staging repin. Production additionally needs `RELAY_IMAGE_TAG` moved to a promoted digest (JP-135 — never `:edge`).

Closes JP-493 (relay half; the web-side holes it exposed are tracked on the same issue).

Assisted-by: Opus 5