### PR TITLE
JP-495: prose can carry a file, inline

### DIFF
--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -2592,6 +2592,75 @@ mod tests {
     }
 
     #[test]
+    fn jp495_file_ref_survives_the_flatten_round_trip() {
+        // The JP-432 failure mode is a node that PARSES but doesn't survive
+        // reserialize — it vanishes on the next flatten, taking the only
+        // reference to its blob with it. Byte-identical is the bar.
+        let handle = DocHandle::hydrate(&empty_json_body(1), None, false);
+        let html = concat!(
+            r#"<p><span data-file-ref data-blob-ref="blob://"#,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            r#"" data-file-name="notes.pdf" data-mime-type="application/pdf" data-file-size="12345">notes.pdf</span></p>"#
+        );
+        handle.replace_prose("p1", html).unwrap();
+        assert_eq!(handle.prose_html("p1").as_deref(), Some(html));
+    }
+
+    #[test]
+    fn jp495_file_ref_keeps_its_blob_discoverable_by_the_reference_walk() {
+        // The point of the URI form (JP-494): a chip's blob must be visible to
+        // refcounting and the publish manifest. A bare hash in the attribute
+        // would be invisible, and nothing would fail loudly — the bytes would
+        // just be swept later.
+        let hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let handle = DocHandle::hydrate(&empty_json_body(1), None, false);
+        handle
+            .replace_prose(
+                "p1",
+                &format!(
+                    r#"<p><span data-file-ref data-blob-ref="blob://{hash}" data-file-name="a.zip">a.zip</span></p>"#
+                ),
+            )
+            .unwrap();
+        let mut body = empty_json_body(1);
+        handle.flatten_into(&mut body);
+        let refs = crate::api::collect_blob_references(&body);
+        assert!(refs.contains(&hash.to_string()), "chip blob not found by the walk: {refs:?}");
+    }
+
+    #[test]
+    fn jp495_file_ref_spacing_is_preserved_mid_sentence() {
+        // Inline atoms are whitespace-sensitive: missing the run-membership or
+        // whitespace rules shows up as a swallowed or doubled space around the
+        // chip, which no schema test would catch.
+        let handle = DocHandle::hydrate(&empty_json_body(1), None, false);
+        let html = concat!(
+            r#"<p>see <span data-file-ref data-blob-ref="blob://"#,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            r#"" data-file-name="spec.pdf">spec.pdf</span> for details</p>"#
+        );
+        handle.replace_prose("p1", html).unwrap();
+        assert_eq!(handle.prose_html("p1").as_deref(), Some(html));
+    }
+
+    #[test]
+    fn jp495_file_ref_survives_inside_a_table_cell() {
+        // The reason the node is inline rather than block (user's call): a block
+        // node cannot live in a cell. This is the case that regressed for
+        // fieldRef when the atom was missing from the inline-run list.
+        let handle = DocHandle::hydrate(&empty_json_body(1), None, false);
+        let html = concat!(
+            // No `<tbody>`: the relay normalizes it away, so writing it here
+            // would test that normalization rather than the chip.
+            r#"<table><tr><td><p><span data-file-ref data-blob-ref="blob://"#,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            r#"" data-file-name="q3.xlsx">q3.xlsx</span></p></td></tr></table>"#
+        );
+        handle.replace_prose("p1", html).unwrap();
+        assert_eq!(handle.prose_html("p1").as_deref(), Some(html));
+    }
+
+    #[test]
     fn jp328_validate_prose_html_reports_a_diff_for_malformed_input() {
         // `validate_prose_html` is what the MCP set_prose/add_prose_page tools
         // call to surface the `fixes` diff to the author. Clean HTML reports no

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -183,6 +183,7 @@ fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
         "bibliography" => Block::Void(bibliography_html(el, txn)),
         "fieldRef" => Block::Void(field_html(el, txn)),
         "mathInline" => Block::Void(math_inline_html(el, txn)),
+        "fileRef" => Block::Void(file_ref_html(el, txn)),
         "mathBlock" => Block::Void(math_block_html(el, txn)),
         // Structural custom blocks (round-trip with the relay parser). `variant`/
         // `layout` are PM attr names → emitted as `data-variant`/`data-layout`.
@@ -449,6 +450,35 @@ fn field_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
     }
     s.push('>');
     push_escaped(&mut s, &label);
+    s.push_str("</span>");
+    s
+}
+
+/// Serialize a `fileRef` element to `<span data-file-ref data-blob-ref=… …>`
+/// (JP-495). Childless. Optional attributes are emitted only when non-empty,
+/// matching the editor's `renderHTML`, so a flatten of an editor-written node is
+/// byte-identical rather than gaining empty attributes each pass.
+///
+/// The filename is also written as the span's **text content**, copying the
+/// `fieldRef` degradation contract: a consumer that doesn't understand the node
+/// unwraps it to something a reader can still use, rather than to nothing.
+fn file_ref_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
+    let mut s = String::from("<span data-file-ref");
+    if let Some(blob_ref) = str_attr(el, txn, "blobRef") {
+        let _ = write!(s, " data-blob-ref=\"{}\"", escape_attr(&blob_ref));
+    }
+    let file_name = str_attr(el, txn, "fileName").unwrap_or_default();
+    if !file_name.is_empty() {
+        let _ = write!(s, " data-file-name=\"{}\"", escape_attr(&file_name));
+    }
+    for (pm_attr, data_attr) in [("mimeType", "data-mime-type"), ("fileSize", "data-file-size")] {
+        let v = str_attr(el, txn, pm_attr).unwrap_or_default();
+        if !v.is_empty() {
+            let _ = write!(s, " {}=\"{}\"", data_attr, escape_attr(&v));
+        }
+    }
+    s.push('>');
+    push_escaped(&mut s, &file_name);
     s.push_str("</span>");
     s
 }

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -528,7 +528,10 @@ fn is_inline_member(n: &HtmlNode) -> bool {
                 || tag == "br"
                 || matches!(
                     prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m)),
-                    Some("fieldRef") | Some("citationInline") | Some("mathInline")
+                    Some("fieldRef")
+                        | Some("citationInline")
+                        | Some("mathInline")
+                        | Some("fileRef")
                 )
         }
     }
@@ -624,6 +627,33 @@ fn field_node(attrs: &[(String, String)]) -> PmNode {
         a.push(("label".to_string(), label.to_string()));
     }
     PmNode { node_type: "fieldRef".to_string(), attrs: a, children: vec![] }
+}
+
+/// Build a `fileRef` PM node from a `<span data-file-ref …>` element (JP-495).
+/// Caller guarantees `data-blob-ref` is non-empty. Only non-empty optional
+/// attributes are emitted, symmetric with the editor's `renderHTML`
+/// (`src/tiptap/FileRefExtension.ts`) — an attr the editor omits must not come
+/// back as an empty string, or a flatten would rewrite the node every time.
+///
+/// `blobRef` keeps its `blob://<hash>` URI form deliberately: the reference walk
+/// only recognizes that grammar inside a string, so storing a bare hash here
+/// would make the blob invisible to refcounting and the publish manifest
+/// (JP-494). It's an atom — no children.
+fn file_ref_node(attrs: &[(String, String)]) -> PmNode {
+    let mut a = vec![(
+        "blobRef".to_string(),
+        get_attr(attrs, "data-blob-ref").unwrap_or("").to_string(),
+    )];
+    for (data_attr, pm_attr) in [
+        ("data-file-name", "fileName"),
+        ("data-mime-type", "mimeType"),
+        ("data-file-size", "fileSize"),
+    ] {
+        if let Some(v) = get_attr(attrs, data_attr).filter(|s| !s.is_empty()) {
+            a.push((pm_attr.to_string(), v.to_string()));
+        }
+    }
+    PmNode { node_type: "fileRef".to_string(), attrs: a, children: vec![] }
 }
 
 /// Build a `mathInline` PM node from a `<span data-math-inline data-latex=…>`
@@ -912,6 +942,17 @@ fn collect_inline(nodes: &[HtmlNode], marks: &[PmMark]) -> Vec<PmChild> {
                     // — a nameless field reference is useless, so fall through to
                     // the unwrap below and keep the text instead.
                     out.push(PmChild::Node(field_node(attrs)));
+                } else if prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m))
+                    == Some("fileRef")
+                    && get_attr(attrs, "data-blob-ref")
+                        .filter(|s| !s.is_empty())
+                        .is_some()
+                {
+                    // Inline file atom (JP-495). Require a non-empty
+                    // `data-blob-ref` — a chip with no blob addresses nothing, so
+                    // fall through to the unwrap below and keep its text (the
+                    // filename) instead.
+                    out.push(PmChild::Node(file_ref_node(attrs)));
                 } else if prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m))
                     == Some("mathInline")
                     && has_attr(attrs, "data-latex")

--- a/relay/src/sync/prose_schema.rs
+++ b/relay/src/sync/prose_schema.rs
@@ -219,6 +219,15 @@ pub const CUSTOM_PROSE_NODES: &[(&str, &str, &str)] = &[
     // field atoms so a flatten doesn't unwrap them. Mirrors `LatexExtension.ts`.
     ("mathInline", "span", "data-math-inline"),
     ("mathBlock", "div", "data-math-block"),
+    // An attached file, inline (JP-495): `<span data-file-ref data-blob-ref
+    // data-file-name data-mime-type data-file-size>`. Inline rather than block
+    // so it composes inside a table cell and mid-sentence, which is what import
+    // fidelity needs. The blob is addressed in **`blob://<hash>` URI form** —
+    // the attribute lives inside an HTML string, so the bare-hash `blobRef`
+    // shape can never be seen there, and only the URI grammar is discoverable
+    // by the reference walk (JP-494), the publish manifest, and the MCP file
+    // tools. Mirrors `src/tiptap/FileRefExtension.ts`.
+    ("fileRef", "span", "data-file-ref"),
 ];
 
 /// PM node type for an HTML element that matches a custom prose-helper node:

--- a/relay/src/sync/prose_validate.rs
+++ b/relay/src/sync/prose_validate.rs
@@ -80,6 +80,10 @@ fn is_known_type(t: &str) -> bool {
             | "taskList"
             | "taskItem"
             | "embeddedGroup"
+            // JP-495: an attached file, inline. Unknown here means "unwrap to
+            // children", and an atom has none — so omitting it deletes the chip
+            // and the only reference to its blob.
+            | "fileRef"
     )
 }
 
@@ -100,6 +104,8 @@ fn is_atom(t: &str) -> bool {
             // JP-432: an embedded canvas group is an atom (`atom: true` in
             // `EmbeddedGroupExtension`) — childless, self-describing via `data-*`.
             | "embeddedGroup"
+            // JP-495: the file chip is `atom: true`, childless, self-describing.
+            | "fileRef"
     )
 }
 

--- a/src/tiptap/FileRefExtension.ts
+++ b/src/tiptap/FileRefExtension.ts
@@ -1,0 +1,151 @@
+/**
+ * Inline file chip (JP-495) — an attached file referenced from prose.
+ *
+ * Inline rather than block so it composes inside a table cell and mid-sentence.
+ * That is also what import fidelity needs: a provider's file block can sit
+ * anywhere, and a block-level node would flatten that placement.
+ *
+ * The blob is addressed in **`blob://<hash>` URI form**, never a bare hash.
+ * Blob references are discovered by exactly two shapes — a bare hash under a
+ * key literally named `blobRef`, or the `blob://` grammar inside a string — and
+ * an HTML attribute is inside a string, so only the URI form is discoverable.
+ * Store a bare hash and the blob is invisible to the reference walk, the
+ * publish manifest, and the MCP file tools, none of which fail loudly; the
+ * bytes are simply swept later (JP-494).
+ *
+ * `fileCategory` is deliberately NOT an attribute — `detectFileCategory` derives
+ * it from the mime + filename, and persisting derived state invites it drifting
+ * out of step with the mime it came from.
+ */
+
+import { Node, mergeAttributes } from '@tiptap/core';
+
+import { detectFileCategory } from '../utils/fileUtils';
+import { getFileTypeLucideIcon } from '../utils/fileTypeIcons';
+import { formatFileSize } from '../utils/byteSize';
+
+export interface FileRefOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+/** The `blob://` URI form the attribute must carry. */
+const BLOB_PREFIX = 'blob://';
+
+/** Strip the URI form down to the bare hash, for callers that resolve bytes. */
+export function fileRefHash(blobRef: string): string {
+  return blobRef.startsWith(BLOB_PREFIX) ? blobRef.slice(BLOB_PREFIX.length) : blobRef;
+}
+
+/**
+ * Inline file node — renders as a chip showing the file's type icon, name, and
+ * size.
+ */
+export const FileRef = Node.create<FileRefOptions>({
+  name: 'fileRef',
+  group: 'inline',
+  inline: true,
+  atom: true,
+
+  addOptions() {
+    return { HTMLAttributes: {} };
+  },
+
+  // Each attribute owns its `data-*` serialization so getHTML emits only clean
+  // `data-*` attributes — the same round-trip shape as FieldRef/CitationInline,
+  // and the shape the relay's `file_ref_html` writes. Optional attributes are
+  // omitted when empty rather than emitted blank, so an editor-written node and
+  // a relay-written one are byte-identical.
+  addAttributes() {
+    return {
+      blobRef: {
+        default: '',
+        parseHTML: (el: HTMLElement) => el.getAttribute('data-blob-ref') ?? '',
+        renderHTML: (attrs) =>
+          attrs['blobRef'] ? { 'data-blob-ref': String(attrs['blobRef']) } : {},
+      },
+      fileName: {
+        default: '',
+        parseHTML: (el: HTMLElement) => el.getAttribute('data-file-name') ?? '',
+        renderHTML: (attrs) =>
+          attrs['fileName'] ? { 'data-file-name': String(attrs['fileName']) } : {},
+      },
+      mimeType: {
+        default: '',
+        parseHTML: (el: HTMLElement) => el.getAttribute('data-mime-type') ?? '',
+        renderHTML: (attrs) =>
+          attrs['mimeType'] ? { 'data-mime-type': String(attrs['mimeType']) } : {},
+      },
+      // Kept as a string end-to-end: it arrives as an HTML attribute and the
+      // relay stores PM attrs as strings, so parsing to a number here would make
+      // an editor-written node differ from a relay-written one on every flatten.
+      fileSize: {
+        default: '',
+        parseHTML: (el: HTMLElement) => el.getAttribute('data-file-size') ?? '',
+        renderHTML: (attrs) =>
+          attrs['fileSize'] ? { 'data-file-size': String(attrs['fileSize']) } : {},
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-file-ref]' }];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const fileName = (node.attrs['fileName'] as string) ?? '';
+    // The filename is also the text child, copying FieldRef's degradation
+    // contract: a consumer that doesn't understand the node still shows
+    // something a reader can use rather than nothing.
+    return [
+      'span',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        'data-file-ref': '',
+        class: 'file-ref',
+      }),
+      fileName,
+    ];
+  },
+
+  addNodeView() {
+    return ({ node }) => {
+      const fileName = (node.attrs['fileName'] as string) ?? '';
+      const mimeType = (node.attrs['mimeType'] as string) ?? '';
+      const rawSize = (node.attrs['fileSize'] as string) ?? '';
+
+      const dom = document.createElement('span');
+      dom.setAttribute('data-file-ref', '');
+      dom.className = 'file-ref';
+      dom.contentEditable = 'false';
+      dom.title = fileName;
+
+      // Derived, never persisted — see the module note.
+      const category = detectFileCategory(mimeType, fileName);
+      const Icon = getFileTypeLucideIcon(category);
+
+      // lucide-react components are React elements; the chip is plain DOM, so
+      // render the icon's SVG shell directly and let CSS size it. Keeping the
+      // node view DOM-only avoids mounting a React root per chip in a document
+      // that may hold many.
+      const iconEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      iconEl.setAttribute('class', 'file-ref-icon');
+      iconEl.setAttribute('aria-hidden', 'true');
+      iconEl.dataset['icon'] = (Icon as { displayName?: string }).displayName ?? category;
+      dom.appendChild(iconEl);
+
+      const label = document.createElement('span');
+      label.className = 'file-ref-name';
+      label.textContent = fileName || 'Attachment';
+      dom.appendChild(label);
+
+      const size = Number(rawSize);
+      if (Number.isFinite(size) && size > 0) {
+        const sizeEl = document.createElement('span');
+        sizeEl.className = 'file-ref-size';
+        sizeEl.textContent = formatFileSize(size);
+        dom.appendChild(sizeEl);
+      }
+
+      return { dom };
+    };
+  },
+});

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -581,6 +581,53 @@
   border: 1px dashed var(--border-color);
 }
 
+/* Inline file chip (JP-495): an attached file referenced from prose. Sized in
+   `em` so it tracks the surrounding text — a chip must sit on a line of body
+   copy and inside a table cell without changing the line height. */
+.tiptap-editor .ProseMirror .file-ref {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35em;
+  max-width: 100%;
+  padding: 0.05em 0.45em;
+  border: 1px solid var(--border-color);
+  /* --radius-full is 50% (an ellipse on a non-square box) — a pill needs the
+     999px token. See the radius-full-is-ellipse note. */
+  border-radius: var(--radius-pill, 999px);
+  background-color: var(--bg-secondary);
+  cursor: pointer;
+  /* The chip is one object: never break the name away from its icon. */
+  white-space: nowrap;
+  vertical-align: baseline;
+}
+
+.tiptap-editor .ProseMirror .file-ref:hover {
+  background-color: var(--bg-tertiary);
+}
+
+.tiptap-editor .ProseMirror .file-ref .file-ref-icon {
+  width: 1em;
+  height: 1em;
+  flex: 0 0 auto;
+  /* Nudge the icon onto the text baseline rather than the box baseline. */
+  transform: translateY(0.15em);
+}
+
+.tiptap-editor .ProseMirror .file-ref .file-ref-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* Shrink the NAME, never the size badge — a truncated size reads as wrong
+     data, whereas a truncated filename reads as truncated. */
+  min-width: 0;
+}
+
+.tiptap-editor .ProseMirror .file-ref .file-ref-size {
+  flex: 0 0 auto;
+  color: var(--text-muted, var(--text-secondary));
+  font-size: 0.85em;
+  font-variant-numeric: tabular-nums;
+}
+
 .tiptap-editor .ProseMirror .bibliography-block {
   margin: 1.5rem 0;
   padding: 1rem;

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -44,6 +44,7 @@ import { MathInline, MathBlock } from '../tiptap/LatexExtension';
 import { CitationInline, Bibliography } from '../tiptap/CitationExtension';
 import { CitationSuggestion } from '../tiptap/CitationSuggestion';
 import { FieldRef } from '../tiptap/FieldExtension';
+import { FileRef } from '../tiptap/FileRefExtension';
 import { FieldSuggestion } from '../tiptap/FieldSuggestion';
 import { SlashMenu } from '../tiptap/SlashMenu';
 import { Callout } from '../tiptap/CalloutExtension';
@@ -241,6 +242,7 @@ export const sharedProseExtensions = [
   // so the headless schema + collab are unaffected. FieldSuggestion must follow
   // FieldRef (it inserts that node).
   FieldRef,
+  FileRef,
   FieldSuggestion,
   // `/`-trigger command palette. Inserts existing nodes (no nodes/marks of its
   // own), so the shared schema + collab are unaffected — like CitationSuggestion.

--- a/src/ui/proseSchemaContract.test.ts
+++ b/src/ui/proseSchemaContract.test.ts
@@ -38,12 +38,15 @@ const RELAY_NODES = new Set<string>([
   'mathBlock', 'callout', 'figure', 'figcaption', 'gallery',
   // JP-432
   'taskList', 'taskItem', 'embeddedGroup',
+  // JP-495: the inline file chip.
+  'fileRef',
 ]);
 
 /** Relay-emitted nodes built childless — the client MUST treat these as atoms. */
 const RELAY_ATOMS = new Set<string>([
   'image', 'citationInline', 'fieldRef', 'mathInline', 'mathBlock',
   'horizontalRule', 'bibliography', 'hardBreak', 'embeddedGroup',
+  'fileRef',
 ]);
 
 /** Every inline mark the relay round-trips (prose_schema.rs MARKS + link). */
@@ -70,6 +73,9 @@ const RELAY_ATTRS: Record<string, Set<string>> = {
   codeBlock: new Set(['language', 'id']),
   image: new Set(['src', 'alt', 'title', 'width', 'height', 'float']),
   taskItem: new Set(['checked']),
+  // JP-495: `blobRef` holds the `blob://<hash>` URI form, not a bare hash, so
+  // the reference walk can find it inside the serialized HTML string.
+  fileRef: new Set(['blobRef', 'fileName', 'mimeType', 'fileSize']),
   embeddedGroup: new Set(['groupId', 'groupName']),
   callout: new Set(['variant']),
   gallery: new Set(['layout']),


### PR DESCRIPTION
First slice of JP-495. Builds on JP-494 (#451), now on `master`.

Notion `file`/`pdf`/`video`/`audio` attachments leave a named notice and no content, because prose has no node that can hold a file. This adds `fileRef` — an inline atom carrying the same content-addressed blob images already use — and binds the relay and editor definitions together.

## Two decisions worth reviewing

**Inline, not block.** A chip composes inside a table cell and mid-sentence, which is what import fidelity needs; a block node would flatten placement the importer already knows.

**The blob is addressed as `blob://<hash>`, never a bare hash.** References are discovered by exactly two shapes — a bare hash under a key named `blobRef`, or the `blob://` grammar *inside a string*. An HTML attribute lives inside a string, so only the URI form is discoverable there. A bare hash would be invisible to the reference walk, the publish manifest, and the MCP file tools — none of which fail loudly; the bytes would just be swept later. A test asserts the walk finds a chip's blob after a flatten.

Also: `fileCategory` is **not** persisted (derived by `detectFileCategory`; storing it invites drift from the mime), and `fileSize` stays a string end to end, since it arrives as an HTML attribute and the relay stores PM attrs as strings — parsing to a number would make an editor-written node differ from a relay-written one on every flatten.

## The part that surprised me

An inline atom is enumerated **by name** across the relay, and my site list was incomplete. **Two of six were found only because the round-trip tests failed:**

| Site | Effect if missed |
|---|---|
| `prose_schema::CUSTOM_PROSE_NODES` | no round-trip at all |
| `prose_parse::is_inline_member` | span breaks the inline run → unwrapped in a table cell |
| `prose_parse::collect_inline` | never parsed |
| `prose_html` dispatch + serializer | never written back |
| **`prose_validate::is_known_type`** | **unknown ⇒ "unwrap to children", and an atom has none — the chip was deleted outright** |
| **`prose_validate::is_atom`** | childlessness is what keeps NodeView reconciliation from crashing (JP-328) |

Every one of these fails *quietly* — a swallowed space, or a node that parses and then vanishes on the next flatten (the JP-432 mode). So the tests are **round-trips through the Y.Doc**, not parse assertions:

- byte-identical flatten with all four attributes
- spacing preserved mid-sentence (`see <chip> for details`)
- survives inside a table cell — the case that regressed for `fieldRef`
- blob still discoverable by `collect_blob_references` after a flatten

## Contract

`fileRef` added to `RELAY_NODES` / `RELAY_ATOMS` / `RELAY_ATTRS`. **Verified it binds:** unregistering the editor extension fails with `client schema must define relay node 'fileRef'`.

## Verification

- `bun run typecheck` — clean
- `bun run test --run` — 3552 passed (297 files)
- `cargo test --manifest-path relay/Cargo.toml --locked` — 26 binaries, all green
- OSS commercial leak grep — clean

## Deliberately not in this PR

Opening the viewer on click (needs `FileViewerModal` to take a descriptor instead of a `shapeId` — §1.4), PDF export representation, MCP file tools, and the Notion connector emitting the node. This is the node itself; those are follow-ups. The chip renders type icon + name + size today, and degrades like `fieldRef` (filename is also the span's text content).

Assisted-by: Opus 5