### PR TITLE
JP-495: make the prose file chip usable by a human

### DIFF
--- a/src/storage/proseFileRefBlobs.test.ts
+++ b/src/storage/proseFileRefBlobs.test.ts
@@ -1,0 +1,61 @@
+/**
+ * A file chip's blob must be visible to the reference walk while the chip
+ * exists, and must drop out when it is removed (JP-495 on top of JP-494).
+ *
+ * This is the whole reason the chip stores `blob://<hash>` rather than a bare
+ * hash: the attribute is serialized inside an HTML string, and only the URI
+ * grammar is discoverable there. Get it wrong and nothing fails — the bytes are
+ * simply swept later, after the reader has moved on.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { deriveBlobReferences } from './AssetBundler';
+import type { DiagramDocument } from '../types/Document';
+
+const HASH = 'c'.repeat(64);
+
+function docWithProse(html: string): DiagramDocument {
+  return {
+    id: 'd1',
+    name: 'chip doc',
+    pages: { p1: { id: 'p1', name: 'Page 1', shapes: {}, shapeOrder: [], connections: {} } },
+    pageOrder: ['p1'],
+    activePageId: 'p1',
+    createdAt: 0,
+    modifiedAt: 0,
+    version: 2,
+    richTextPages: {
+      pages: {
+        rp1: { id: 'rp1', name: 'Prose', content: html, order: 0, createdAt: 0, modifiedAt: 0 },
+      },
+      pageOrder: ['rp1'],
+      activePageId: 'rp1',
+    },
+  } as unknown as DiagramDocument;
+}
+
+const chip = (ref: string) =>
+  `<p>See <span data-file-ref data-blob-ref="${ref}" data-file-name="a.pdf" data-mime-type="application/pdf" data-file-size="10">a.pdf</span></p>`;
+
+describe('file chip blob lifecycle', () => {
+  it('finds the blob of a chip that stores the blob:// URI form', () => {
+    expect(deriveBlobReferences(docWithProse(chip(`blob://${HASH}`)))).toEqual([HASH]);
+  });
+
+  it('does NOT find a chip that stored a bare hash — the failure this design avoids', () => {
+    // Pinned deliberately: if someone "simplifies" the attribute to a bare hash,
+    // this test is what tells them the blob just became invisible to GC rather
+    // than letting them find out from a support report.
+    expect(deriveBlobReferences(docWithProse(chip(HASH)))).toEqual([]);
+  });
+
+  it('releases the blob when the chip is removed', () => {
+    const before = deriveBlobReferences(docWithProse(chip(`blob://${HASH}`)));
+    const after = deriveBlobReferences(docWithProse('<p>See </p>'));
+    expect(before).toEqual([HASH]);
+    // Derived from live content, so a removed chip genuinely drops the
+    // reference — a union with the stored array could never shrink.
+    expect(after).toEqual([]);
+  });
+});

--- a/src/store/sessionStore.test.ts
+++ b/src/store/sessionStore.test.ts
@@ -396,14 +396,14 @@ describe('Session Store', () => {
   describe('file viewing', () => {
     it('starts with no file being viewed', () => {
       const state = useSessionStore.getState();
-      expect(state.viewingFileShapeId).toBeNull();
+      expect(state.viewingFile).toBeNull();
       expect(state.isViewingFile()).toBe(false);
     });
 
     it('opens file viewer', () => {
       useSessionStore.getState().openFileViewer('file-shape-1');
       const state = useSessionStore.getState();
-      expect(state.viewingFileShapeId).toBe('file-shape-1');
+      expect(state.viewingFile).toEqual({ source: 'shape', shapeId: 'file-shape-1' });
       expect(state.isViewingFile()).toBe(true);
     });
 
@@ -411,16 +411,44 @@ describe('Session Store', () => {
       useSessionStore.getState().openFileViewer('file-shape-1');
       useSessionStore.getState().closeFileViewer();
       const state = useSessionStore.getState();
-      expect(state.viewingFileShapeId).toBeNull();
+      expect(state.viewingFile).toBeNull();
       expect(state.isViewingFile()).toBe(false);
+    });
+
+    it('opens a file that has no shape (a prose chip)', () => {
+      // The whole point of the union: prose describes its file inline because
+      // there is no shape to look up.
+      const descriptor = {
+        blobRef: 'a'.repeat(64),
+        fileName: 'notes.pdf',
+        mimeType: 'application/pdf',
+        fileSize: 20,
+        fileCategory: 'pdf' as const,
+      };
+      useSessionStore.getState().openFileViewerFor(descriptor);
+      expect(useSessionStore.getState().viewingFile).toEqual({ source: 'prose', descriptor });
+      expect(useSessionStore.getState().isViewingFile()).toBe(true);
+    });
+
+    it('a prose file closes the same way a shape does', () => {
+      useSessionStore.getState().openFileViewerFor({
+        blobRef: 'b'.repeat(64),
+        fileName: 'x.txt',
+        mimeType: 'text/plain',
+        fileSize: 1,
+        fileCategory: 'text',
+      });
+      useSessionStore.getState().closeFileViewer();
+      expect(useSessionStore.getState().viewingFile).toBeNull();
+      expect(useSessionStore.getState().isViewingFile()).toBe(false);
     });
 
     it('can switch between different files', () => {
       useSessionStore.getState().openFileViewer('file-1');
-      expect(useSessionStore.getState().viewingFileShapeId).toBe('file-1');
+      expect(useSessionStore.getState().viewingFile).toEqual({ source: 'shape', shapeId: 'file-1' });
 
       useSessionStore.getState().openFileViewer('file-2');
-      expect(useSessionStore.getState().viewingFileShapeId).toBe('file-2');
+      expect(useSessionStore.getState().viewingFile).toEqual({ source: 'shape', shapeId: 'file-2' });
     });
   });
 

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -3,6 +3,12 @@ import { useDocumentStore } from './documentStore';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
 import type { Shape } from '../shapes/Shape';
 import type { RelaxedFocus } from '../ui/layout/types';
+import type { FileDescriptor } from '../ui/fileDescriptor';
+
+/** What the file viewer is currently showing. */
+export type ViewedFile =
+  | { source: 'shape'; shapeId: string }
+  | { source: 'prose'; descriptor: FileDescriptor };
 
 /**
  * Core tool types that are always available.
@@ -125,8 +131,15 @@ export interface SessionState {
   hoveredId: string | null;
   /** ID of text shape currently being edited (null if not editing) */
   editingTextId: string | null;
-  /** ID of file shape currently being viewed in modal (null if not viewing) */
-  viewingFileShapeId: string | null;
+  /**
+   * The file currently open in the viewer, or null (JP-495).
+   *
+   * A discriminated union rather than a shape id: prose file chips have no
+   * shape, and a parallel `viewingProseFile` field would be a second source of
+   * truth for one exclusive piece of UI state. The canvas case stays an id so
+   * the viewer keeps tracking live edits to the shape.
+   */
+  viewingFile: ViewedFile | null;
   /**
    * How the file viewer hosts its content: full-screen modal or the floating
    * side panel. Sticky for the session — opening another file keeps the mode.
@@ -203,7 +216,10 @@ export interface SessionActions {
   isEditingText: () => boolean;
 
   // File viewing
+  /** Open a canvas file shape. */
   openFileViewer: (id: string) => void;
+  /** Open a file that isn't a shape — a prose chip describes itself. */
+  openFileViewerFor: (descriptor: FileDescriptor) => void;
   closeFileViewer: () => void;
   setFileViewerMode: (mode: 'modal' | 'floating') => void;
   isViewingFile: () => boolean;
@@ -294,7 +310,7 @@ const initialState: SessionState = {
   isInteracting: false,
   hoveredId: null,
   editingTextId: null,
-  viewingFileShapeId: null,
+  viewingFile: null,
   fileViewerMode: 'modal',
   snapSettings: { ...DEFAULT_SNAP_SETTINGS },
   snapGuides: {},
@@ -423,11 +439,15 @@ export const useSessionStore = create<SessionState & SessionActions>()((set, get
 
   // File viewing
   openFileViewer: (id: string) => {
-    set({ viewingFileShapeId: id });
+    set({ viewingFile: { source: 'shape', shapeId: id } });
+  },
+
+  openFileViewerFor: (descriptor: FileDescriptor) => {
+    set({ viewingFile: { source: 'prose', descriptor } });
   },
 
   closeFileViewer: () => {
-    set({ viewingFileShapeId: null });
+    set({ viewingFile: null });
   },
 
   setFileViewerMode: (mode: 'modal' | 'floating') => {
@@ -435,7 +455,7 @@ export const useSessionStore = create<SessionState & SessionActions>()((set, get
   },
 
   isViewingFile: (): boolean => {
-    return get().viewingFileShapeId !== null;
+    return get().viewingFile !== null;
   },
 
   // Snapping

--- a/src/tiptap/FileRefExtension.ts
+++ b/src/tiptap/FileRefExtension.ts
@@ -19,21 +19,36 @@
  */
 
 import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer } from '@tiptap/react';
 
-import { detectFileCategory } from '../utils/fileUtils';
-import { getFileTypeLucideIcon } from '../utils/fileTypeIcons';
-import { formatFileSize } from '../utils/byteSize';
+import { FileRefChip } from '../ui/FileRefChip';
 
 export interface FileRefOptions {
   HTMLAttributes: Record<string, unknown>;
 }
 
-/** The `blob://` URI form the attribute must carry. */
-const BLOB_PREFIX = 'blob://';
+/**
+ * What a chip stores. `blobRef` is the **`blob://<hash>` URI form**, never a
+ * bare hash — the attribute lives inside an HTML string, and only that grammar
+ * is discoverable by the blob reference walk (JP-494). `fileSize` is a string
+ * because it arrives as an HTML attribute and the relay stores PM attrs as
+ * strings; parsing it here would make an editor-written node differ from a
+ * relay-written one on every flatten.
+ */
+export interface FileRefAttrs {
+  blobRef: string;
+  fileName: string;
+  mimeType: string;
+  fileSize: string;
+}
 
-/** Strip the URI form down to the bare hash, for callers that resolve bytes. */
-export function fileRefHash(blobRef: string): string {
-  return blobRef.startsWith(BLOB_PREFIX) ? blobRef.slice(BLOB_PREFIX.length) : blobRef;
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    fileRef: {
+      /** Insert an inline file chip at the current selection. */
+      insertFileRef: (attrs: FileRefAttrs) => ReturnType;
+    };
+  }
 }
 
 /**
@@ -107,45 +122,23 @@ export const FileRef = Node.create<FileRefOptions>({
   },
 
   addNodeView() {
-    return ({ node }) => {
-      const fileName = (node.attrs['fileName'] as string) ?? '';
-      const mimeType = (node.attrs['mimeType'] as string) ?? '';
-      const rawSize = (node.attrs['fileSize'] as string) ?? '';
+    return ReactNodeViewRenderer(FileRefChip);
+  },
 
-      const dom = document.createElement('span');
-      dom.setAttribute('data-file-ref', '');
-      dom.className = 'file-ref';
-      dom.contentEditable = 'false';
-      dom.title = fileName;
-
-      // Derived, never persisted — see the module note.
-      const category = detectFileCategory(mimeType, fileName);
-      const Icon = getFileTypeLucideIcon(category);
-
-      // lucide-react components are React elements; the chip is plain DOM, so
-      // render the icon's SVG shell directly and let CSS size it. Keeping the
-      // node view DOM-only avoids mounting a React root per chip in a document
-      // that may hold many.
-      const iconEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-      iconEl.setAttribute('class', 'file-ref-icon');
-      iconEl.setAttribute('aria-hidden', 'true');
-      iconEl.dataset['icon'] = (Icon as { displayName?: string }).displayName ?? category;
-      dom.appendChild(iconEl);
-
-      const label = document.createElement('span');
-      label.className = 'file-ref-name';
-      label.textContent = fileName || 'Attachment';
-      dom.appendChild(label);
-
-      const size = Number(rawSize);
-      if (Number.isFinite(size) && size > 0) {
-        const sizeEl = document.createElement('span');
-        sizeEl.className = 'file-ref-size';
-        sizeEl.textContent = formatFileSize(size);
-        dom.appendChild(sizeEl);
-      }
-
-      return { dom };
+  addCommands() {
+    return {
+      /**
+       * Insert a file chip at the selection. One transaction, so undo removes
+       * the chip in a single step.
+       */
+      insertFileRef:
+        (attrs: FileRefAttrs) =>
+        ({ commands }) => {
+          // `insertContent` leaves the caret AFTER the inserted node, which is
+          // what lets a writer keep typing mid-sentence — the whole reason this
+          // node is inline rather than a block.
+          return commands.insertContent({ type: this.name, attrs });
+        },
     };
   },
 });

--- a/src/tiptap/proseDropGuard.ts
+++ b/src/tiptap/proseDropGuard.ts
@@ -1,0 +1,27 @@
+/**
+ * Swallow file drops onto a prose editor (JP-495).
+ *
+ * Inserting a dropped file isn't built yet — but doing *nothing* is not the
+ * neutral option. With no handler the browser falls back to its default for a
+ * dropped file: navigate away and display it, discarding whatever was unsaved in
+ * the editor. So the absence of a feature is a data-loss path, and this closes
+ * it until drag-to-attach lands.
+ *
+ * Shared because there are **two** prose editors (`TiptapEditor` and
+ * `CollaborativeProseEditor`); a guard wired into only one leaves the other
+ * destructive, and nothing would fail to tell us.
+ */
+
+import type { EditorView } from '@tiptap/pm/view';
+
+/**
+ * ProseMirror `handleDrop`: consume a drop carrying files, ignore everything
+ * else (text and internal node drags must keep working).
+ *
+ * Returns true when the event was consumed.
+ */
+export function handleProseFileDrop(_view: EditorView, event: DragEvent): boolean {
+  if (!event.dataTransfer?.files?.length) return false;
+  event.preventDefault();
+  return true;
+}

--- a/src/tiptap/slashCommands.ts
+++ b/src/tiptap/slashCommands.ts
@@ -29,7 +29,7 @@ export interface SlashCommand {
 // ─── UI-flow seam (inserts whose UI lives in React) ──────────────────────────
 
 /** Inserts that open React UI rather than running a pure editor command. */
-export type SlashUiAction = 'image' | 'citation' | 'gallery' | 'field';
+export type SlashUiAction = 'image' | 'citation' | 'gallery' | 'field' | 'file';
 
 const uiHandlers = new Map<SlashUiAction, () => void>();
 
@@ -66,6 +66,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { id: 'table', title: 'Table', keywords: ['table', 'grid'], group: 'Insert', run: (e) => cmd.insertTable(e) },
   { id: 'math', title: 'Math block', keywords: ['math', 'latex', 'equation', 'formula'], group: 'Insert', run: (e) => cmd.setMathBlock(e, '') },
   { id: 'image', title: 'Image', keywords: ['image', 'picture', 'photo', 'upload'], group: 'Insert', run: () => runUi('image') },
+  { id: 'file', title: 'File attachment', keywords: ['file', 'attach', 'attachment', 'document', 'pdf', 'upload'], group: 'Insert', run: () => runUi('file') },
   { id: 'gallery', title: 'Image gallery', keywords: ['gallery', 'images', 'grid', 'photos', 'album'], group: 'Insert', run: () => runUi('gallery') },
   { id: 'field', title: 'Field', keywords: ['field', 'variable', 'merge', 'term', 'placeholder', 'value'], group: 'Insert', run: () => runUi('field') },
   { id: 'citation', title: 'Citation', keywords: ['cite', 'citation', 'reference', 'source'], group: 'References', run: () => runUi('citation') },

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback, lazy, Suspense } from 'react'
 import './App.css';
 import './mobile/mobile.css';
 import { CanvasContainer } from './CanvasContainer';
+import { FileViewerHost } from './FileViewerHost';
 import { PropertyPanel } from './PropertyPanel';
 import { LayerPanel } from './LayerPanel';
 import { NavigatorPanel } from './NavigatorPanel';
@@ -731,6 +732,11 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
       {/* Cloud sign-in / workspace management modal (portaled over any view) */}
       <CloudSignInHost />
       <AccessPanelHost />
+
+      {/* File viewer — app-level, not inside the canvas: a collapsed canvas is
+          `display: none`, and a prose chip is usually clicked with the canvas
+          hidden (Relaxed → Write). */}
+      <FileViewerHost />
     </div>
   );
 }

--- a/src/ui/CanvasContainer.tsx
+++ b/src/ui/CanvasContainer.tsx
@@ -5,10 +5,6 @@ import { TextEditor } from './TextEditor';
 import { ContextMenu } from './ContextMenu';
 import { ExportDialog } from './ExportDialog';
 import { SaveToLibraryDialog } from './SaveToLibraryDialog';
-import { FileViewerModal } from './FileViewerModal';
-import { FloatingFileViewer } from './FloatingFileViewer';
-import { resolveViewerMode } from './fileViewerMode';
-import { useMobileAdaptation } from './layout/useMobileAdaptation';
 import { CollaborativeCursors } from './CollaborativeCursors';
 import { SelectionHighlight } from './SelectionHighlight';
 import { Minimap } from './Minimap';
@@ -94,12 +90,6 @@ export function CanvasContainer({
 
   // Save to library dialog state
   const [saveToLibraryOpen, setSaveToLibraryOpen] = useState(false);
-
-  // File viewer state
-  const viewingFileShapeId = useSessionStore((state) => state.viewingFileShapeId);
-  const closeFileViewer = useSessionStore((state) => state.closeFileViewer);
-  const fileViewerMode = useSessionStore((state) => state.fileViewerMode);
-  const { mobileActive } = useMobileAdaptation();
 
   // Let non-canvas UI (file viewer "send page to canvas") import at the
   // viewport center while this canvas is mounted.
@@ -635,18 +625,6 @@ export function CanvasContainer({
         isOpen={saveToLibraryOpen}
         onClose={handleCloseSaveToLibrary}
       />
-      {viewingFileShapeId &&
-        (resolveViewerMode(fileViewerMode, mobileActive) === 'floating' ? (
-          <FloatingFileViewer
-            shapeId={viewingFileShapeId}
-            onClose={closeFileViewer}
-          />
-        ) : (
-          <FileViewerModal
-            shapeId={viewingFileShapeId}
-            onClose={closeFileViewer}
-          />
-        ))}
     </div>
   );
 }

--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -32,6 +32,7 @@ import type { Doc as YDoc } from 'yjs';
 import type { Awareness } from 'y-protocols/awareness';
 import type { AnyExtension } from '@tiptap/core';
 import { sharedProseExtensions } from './TiptapEditor';
+import { handleProseFileDrop } from '../tiptap/proseDropGuard';
 import { handleCitationDoiPaste } from '../tiptap/citationPaste';
 import { useRichTextStore } from '../store/richTextStore';
 import { useRichTextPagesStore, usePageMirror } from '../store/richTextPagesStore';
@@ -120,6 +121,9 @@ export function CollaborativeProseEditor({
         attributes: { class: 'tiptap-prose' },
         // Paste a bare DOI → resolve + add to the library + insert a citation.
         handlePaste: (view, event) => handleCitationDoiPaste(view, event),
+        // Same file-drop guard as the non-collab editor — the browser default
+        // would navigate away and lose unsaved state (JP-495).
+        handleDrop: (view, event) => handleProseFileDrop(view, event as DragEvent),
       },
       onUpdate: ({ editor }) => {
         const json = editor.getJSON();

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -37,6 +37,7 @@ import { useActiveDocReadOnly } from '../store/documentRegistry';
 import * as cmd from './editorCommands';
 import { registerSlashUiHandler } from '../tiptap/slashCommands';
 import { ImageUploadButton } from './ImageUploadButton';
+import { FileUploadButton } from './FileUploadButton';
 import { GalleryUploadButton } from './GalleryUploadButton';
 import { SearchReplacePanel } from './SearchReplacePanel';
 import { ToolbarDropdown } from './ToolbarDropdown';
@@ -525,6 +526,7 @@ export function DocumentEditorToolbar() {
             {/* Media */}
             <div className="document-editor-toolbar-group">
               <ImageUploadButton className="document-editor-toolbar-btn" />
+              <FileUploadButton className="document-editor-toolbar-btn" />
               <GalleryUploadButton className="document-editor-toolbar-btn" />
               <button className="document-editor-toolbar-btn" onClick={() => editor && cmd.insertHorizontalRule(editor)} title="Horizontal Rule" aria-label="Horizontal rule">
                 <Minus {...ICON} />

--- a/src/ui/FileRefChip.tsx
+++ b/src/ui/FileRefChip.tsx
@@ -1,0 +1,147 @@
+/**
+ * The inline file chip rendered for a `fileRef` prose node (JP-495).
+ *
+ * A React node view rather than plain DOM because the file-type icons are React
+ * components (`getFileTypeLucideIcon`) — the first cut built the chip by hand
+ * and produced an empty `<svg>`, so every chip rendered with a blank icon slot.
+ *
+ * The chip reports **state**, not just a name: a file whose bytes aren't
+ * available looks different from one that opens, so a reader isn't invited to
+ * click something that cannot work. That vocabulary (muted + dashed) is
+ * borrowed from `.field-ref-unset` so the two inline atoms read as one system.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
+import { Download } from 'lucide-react';
+
+import { Icon } from './icons';
+import { useSessionStore } from '../store/sessionStore';
+import { blobStorage } from '../storage/BlobStorage';
+import { isBlobMissing, onBlobLoad } from '../storage/blobResolver';
+import { downloadBlob } from '../utils/downloadUtils';
+import { detectFileCategory, truncateFileNameForDisplay } from '../utils/fileUtils';
+import { getFileTypeLucideIcon } from '../utils/fileTypeIcons';
+import { formatFileSize } from '../utils/byteSize';
+import { toBlobHash, type FileDescriptor } from './fileDescriptor';
+
+/** Longest filename shown before the stem is truncated (the extension stays). */
+const MAX_NAME_CHARS = 28;
+
+export function FileRefChip({ node }: NodeViewProps) {
+  const openFileViewerFor = useSessionStore((s) => s.openFileViewerFor);
+
+  const blobUri = (node.attrs['blobRef'] as string) ?? '';
+  const fileName = (node.attrs['fileName'] as string) ?? '';
+  const mimeType = (node.attrs['mimeType'] as string) ?? '';
+  const rawSize = (node.attrs['fileSize'] as string) ?? '';
+
+  const hash = toBlobHash(blobUri);
+  const size = Number(rawSize);
+  const hasSize = Number.isFinite(size) && size > 0;
+
+  // Derived, never persisted — a stored category can drift from its mime.
+  const category = detectFileCategory(mimeType, fileName);
+  const FileIcon = getFileTypeLucideIcon(category);
+
+  const [missing, setMissing] = useState(() => isBlobMissing(hash) === true);
+  const [busy, setBusy] = useState(false);
+
+  // `isBlobMissing` is a cache peek, so re-check when the blob layer reports a
+  // change — a chip that was unavailable offline should recover on its own once
+  // the bytes arrive, without the reader reloading.
+  useEffect(() => {
+    setMissing(isBlobMissing(hash) === true);
+    return onBlobLoad(() => setMissing(isBlobMissing(hash) === true));
+  }, [hash]);
+
+  const open = useCallback(() => {
+    if (!hash) return;
+    const descriptor: FileDescriptor = {
+      blobRef: hash,
+      fileName,
+      mimeType,
+      fileSize: hasSize ? size : 0,
+      fileCategory: category,
+      // Keyed by content: the same attachment resumes where the reader left it,
+      // and a chip has no durable id of its own to key on.
+      sourceId: hash,
+      // No onReplace/onRecover — prose has nowhere to write a new reference
+      // back to, so the viewer hides both affordances rather than offering an
+      // action that would silently do nothing.
+    };
+    openFileViewerFor(descriptor);
+  }, [hash, fileName, mimeType, size, hasSize, category, openFileViewerFor]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // An inline atom with a click handler and no keyboard path is unreachable
+      // for anyone not using a mouse.
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        open();
+      }
+    },
+    [open],
+  );
+
+  const handleDownload = useCallback(
+    async (e: React.MouseEvent) => {
+      // Don't also open the viewer — download is the shortcut past it.
+      e.stopPropagation();
+      if (!hash || busy) return;
+      setBusy(true);
+      try {
+        const blob = await blobStorage.loadBlob(hash);
+        if (blob) downloadBlob(blob, fileName || 'attachment');
+      } catch (err) {
+        console.error('FileRefChip: download failed', err);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [hash, fileName, busy],
+  );
+
+  const displayName = fileName || 'Attachment';
+  const shownName = truncateFileNameForDisplay(displayName, MAX_NAME_CHARS);
+  const sizeLabel = hasSize ? formatFileSize(size) : '';
+
+  const label = missing
+    ? `${displayName} — file unavailable`
+    : `Open ${displayName}${sizeLabel ? `, ${sizeLabel}` : ''}`;
+
+  return (
+    <NodeViewWrapper
+      as="span"
+      className={`file-ref${missing ? ' file-ref-missing' : ''}${busy ? ' file-ref-busy' : ''}`}
+      data-file-ref=""
+      contentEditable={false}
+      role="button"
+      tabIndex={0}
+      aria-label={label}
+      // The full name, since the visible one may be truncated.
+      title={missing ? `${displayName} (unavailable)` : displayName}
+      onClick={open}
+      onKeyDown={handleKeyDown}
+    >
+      <Icon icon={FileIcon} size={14} className="file-ref-icon" />
+      <span className="file-ref-name">{shownName}</span>
+      {sizeLabel && <span className="file-ref-size">{sizeLabel}</span>}
+      {!missing && (
+        <button
+          type="button"
+          className="file-ref-download"
+          onClick={handleDownload}
+          disabled={busy}
+          // The chip already carries the file's name for screen readers.
+          aria-label={`Download ${displayName}`}
+          title="Download"
+          tabIndex={-1}
+        >
+          <Icon icon={Download} size={12} />
+        </button>
+      )}
+    </NodeViewWrapper>
+  );
+}

--- a/src/ui/FileUploadButton.tsx
+++ b/src/ui/FileUploadButton.tsx
@@ -1,0 +1,95 @@
+/**
+ * FileUploadButton — attach a file to prose (JP-495).
+ *
+ * Mirrors `ImageUploadButton`: pick a file, persist it to blob storage, insert
+ * the node. No `accept` filter — the point of an attachment is that it can be
+ * anything (images have their own button, which also processes and downscales).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Paperclip } from 'lucide-react';
+
+import { Icon } from './icons';
+import { useTiptapEditor } from './TiptapEditorContext';
+import { uploadProseFile } from './proseFileUpload';
+import { registerSlashUiHandler } from '../tiptap/slashCommands';
+import { useNotificationStore } from '../store/notificationStore';
+
+export interface FileUploadButtonProps {
+  className?: string;
+}
+
+export function FileUploadButton({ className }: FileUploadButtonProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const editor = useTiptapEditor();
+
+  const handleFileSelect = async (file: File) => {
+    setIsUploading(true);
+    try {
+      const attrs = await uploadProseFile(file);
+      // Insert after the write succeeds: a chip pointing at a blob that failed
+      // to store would render as permanently unavailable.
+      editor?.chain().focus().insertFileRef(attrs).run();
+    } catch (error) {
+      console.error('Failed to attach file:', error);
+      useNotificationStore
+        .getState()
+        .error(error instanceof Error ? error.message : 'Failed to attach that file.');
+    } finally {
+      setIsUploading(false);
+      // Reset so picking the same file twice still fires a change event.
+      if (inputRef.current) inputRef.current.value = '';
+    }
+  };
+
+  const handleClick = () => inputRef.current?.click();
+
+  // `/file` opens this same picker — the upload flow lives here, not in the
+  // editor. No-op headless: nothing is registered.
+  useEffect(() => registerSlashUiHandler('file', () => inputRef.current?.click()), []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFileSelect(file);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`toolbar-button ${className ?? ''}`}
+        onClick={handleClick}
+        disabled={isUploading}
+        title="Attach file"
+        aria-label="Attach file"
+      >
+        {isUploading ? (
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+            <circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" strokeWidth="2" opacity="0.3" />
+            <path d="M8 2 A6 6 0 0 1 14 8" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <animateTransform
+                attributeName="transform"
+                type="rotate"
+                from="0 8 8"
+                to="360 8 8"
+                dur="1s"
+                repeatCount="indefinite"
+              />
+            </path>
+          </svg>
+        ) : (
+          <Icon icon={Paperclip} />
+        )}
+      </button>
+
+      <input
+        ref={inputRef}
+        type="file"
+        onChange={handleChange}
+        style={{ display: 'none' }}
+        aria-hidden="true"
+      />
+    </>
+  );
+}

--- a/src/ui/FileViewerContent.tsx
+++ b/src/ui/FileViewerContent.tsx
@@ -25,7 +25,7 @@ import { formatFileSize } from '../utils/byteSize';
 import { downloadBlob } from '../utils/downloadUtils';
 import { getFileTypeLucideIcon } from '../utils/fileTypeIcons';
 import { Icon } from './icons';
-import { replaceFileContents, reuploadMissingBlob } from '../services/FileReplaceService';
+import type { FileDescriptor } from './fileDescriptor';
 import { citePdf, citeDoi, citeMinimal, type CitePdfStatus } from '../services/citations/citePdf';
 import { useNotificationStore } from '../store/notificationStore';
 import './FileViewerModal.css';
@@ -47,7 +47,8 @@ export function useFileShape(shapeId: string): FileShape | null {
 }
 
 export interface FileViewerContentProps {
-  shapeId: string;
+  /** What to show. Hosts build this; see `fileDescriptor.ts`. */
+  descriptor: FileDescriptor;
   onClose: () => void;
   /** Host-owned immersive reading mode (PDF only). */
   immersive?: boolean | undefined;
@@ -62,7 +63,7 @@ export interface FileViewerContentProps {
 }
 
 export function FileViewerContent({
-  shapeId,
+  descriptor,
   onClose,
   immersive,
   onImmersiveChange,
@@ -70,7 +71,6 @@ export function FileViewerContent({
   headerExtras,
   headerPointerDown,
 }: FileViewerContentProps) {
-  const fileShape = useFileShape(shapeId);
 
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -86,8 +86,8 @@ export function FileViewerContent({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const recoveryInputRef = useRef<HTMLInputElement>(null);
 
-  const blobRef = fileShape?.blobRef;
-  const fileName = fileShape?.fileName ?? '';
+  const blobRef = descriptor.blobRef;
+  const fileName = descriptor.fileName ?? '';
 
   // Load blob on mount. resolveBlobObjectUrl checks the shared object-URL cache,
   // then local IndexedDB, then downloads from the relay/R2 on a miss — so a file
@@ -157,8 +157,8 @@ export function FileViewerContent({
 
       setIsReplacing(true);
       try {
-        const result = await replaceFileContents(shapeId, file);
-        if (result.success) {
+        const replaced = await descriptor.onReplace?.(file);
+        if (replaced) {
           // Trigger reload. The old object URL is owned by the resolver cache
           // (content-addressed, reclaimed on doc switch) — don't revoke it here.
           // The new blobRef makes the load effect re-resolve the replacement.
@@ -174,7 +174,7 @@ export function FileViewerContent({
         }
       }
     },
-    [shapeId]
+    [descriptor]
   );
 
   // Recovery: re-upload missing blob
@@ -189,8 +189,8 @@ export function FileViewerContent({
 
       setIsReplacing(true);
       try {
-        const result = await reuploadMissingBlob(shapeId, file);
-        if (result.success) {
+        const recovered = await descriptor.onRecover?.(file);
+        if (recovered) {
           setIsMissingBlob(false);
           setError(null);
           setLoading(true);
@@ -202,7 +202,7 @@ export function FileViewerContent({
         }
       }
     },
-    [shapeId]
+    [descriptor]
   );
 
   // Cite this PDF: auto-detect the DOI, resolve, import. No DOI → popover.
@@ -272,12 +272,12 @@ export function FileViewerContent({
     }
   }, [blobRef]);
 
-  if (!fileShape) {
+  if (!descriptor) {
     return null;
   }
 
-  const displayName = fileShape.label || fileShape.fileName;
-  const FileIcon = getFileTypeLucideIcon(fileShape.fileCategory);
+  const displayName = descriptor.label || descriptor.fileName;
+  const FileIcon = getFileTypeLucideIcon(descriptor.fileCategory);
 
   return (
     <div className="file-viewer-content">
@@ -289,19 +289,19 @@ export function FileViewerContent({
       >
         <div className="file-viewer-header-info">
           <span className="file-viewer-icon"><Icon icon={FileIcon} size={18} /></span>
-          <span className="file-viewer-filename" title={fileShape.fileName}>
+          <span className="file-viewer-filename" title={descriptor.fileName}>
             {displayName}
           </span>
           <span className="file-viewer-meta">
-            {formatFileSize(fileShape.fileSize)}
+            {formatFileSize(descriptor.fileSize)}
           </span>
           <span className="file-viewer-meta file-viewer-mime">
-            {fileShape.mimeType}
+            {descriptor.mimeType}
           </span>
         </div>
         <div className="file-viewer-header-actions">
           {headerExtras}
-          {resolveViewerCategory(fileShape.fileCategory, fileShape.mimeType) === 'pdf' && (
+          {resolveViewerCategory(descriptor.fileCategory, descriptor.mimeType) === 'pdf' && (
             <button
               className="file-viewer-action-btn"
               onClick={handleCite}
@@ -320,6 +320,7 @@ export function FileViewerContent({
           >
             <Icon icon={Info} size={14} />
           </button>
+          {descriptor.onReplace && (
           <button
             className="file-viewer-action-btn"
             onClick={handleReplaceClick}
@@ -335,6 +336,7 @@ export function FileViewerContent({
               </>
             )}
           </button>
+          )}
           <button
             className="file-viewer-action-btn"
             onClick={handleDownload}
@@ -413,20 +415,20 @@ export function FileViewerContent({
         <div className="file-viewer-info" role="dialog" aria-label="File info">
           <dl className="file-viewer-info-grid">
             <dt>Name</dt>
-            <dd title={fileShape.fileName}>{fileShape.fileName}</dd>
+            <dd title={descriptor.fileName}>{descriptor.fileName}</dd>
             <dt>Size</dt>
-            <dd>{formatFileSize(fileShape.fileSize)}</dd>
+            <dd>{formatFileSize(descriptor.fileSize)}</dd>
             <dt>Type</dt>
-            <dd>{fileShape.mimeType}</dd>
-            {fileShape.preview?.pageCount !== undefined && (
+            <dd>{descriptor.mimeType}</dd>
+            {descriptor.preview?.pageCount !== undefined && (
               <>
                 <dt>Pages</dt>
-                <dd>{fileShape.preview.pageCount}</dd>
+                <dd>{descriptor.preview.pageCount}</dd>
               </>
             )}
             <dt>Checksum</dt>
             <dd className="file-viewer-info-hash">
-              <code title={fileShape.blobRef}>{fileShape.blobRef.slice(0, 12)}…</code>
+              <code title={descriptor.blobRef}>{descriptor.blobRef.slice(0, 12)}…</code>
               <button
                 className="file-viewer-info-copy"
                 onClick={handleCopyHash}
@@ -461,16 +463,19 @@ export function FileViewerContent({
             <span className="file-viewer-recovery-icon"><Icon icon={FolderOpen} size={28} /></span>
             <span className="file-viewer-recovery-title">File Not Found</span>
             <p className="file-viewer-recovery-message">
-              The file content is missing from local storage.
-              Re-upload the original file to restore it.
+              {descriptor.onRecover
+                ? 'The file content is missing from local storage. Re-upload the original file to restore it.'
+                : 'The file content is missing from local storage.'}
             </p>
-            <button
-              className="file-viewer-recovery-btn"
-              onClick={handleRecoveryClick}
-              disabled={isReplacing}
-            >
-              {isReplacing ? 'Uploading...' : 'Re-upload File'}
-            </button>
+            {descriptor.onRecover && (
+              <button
+                className="file-viewer-recovery-btn"
+                onClick={handleRecoveryClick}
+                disabled={isReplacing}
+              >
+                {isReplacing ? 'Uploading...' : 'Re-upload File'}
+              </button>
+            )}
           </div>
         )}
         {!loading && !error && blobUrl && (
@@ -482,7 +487,7 @@ export function FileViewerContent({
               </div>
             }
           >
-            {renderViewer(fileShape, blobUrl, immersive === true, onImmersiveChange)}
+            {renderViewer(descriptor, blobUrl, immersive === true, onImmersiveChange)}
           </Suspense>
         )}
       </div>
@@ -491,7 +496,7 @@ export function FileViewerContent({
 }
 
 function renderViewer(
-  shape: FileShape,
+  shape: FileDescriptor,
   blobUrl: string,
   immersive: boolean,
   onImmersiveChange: ((immersive: boolean) => void) | undefined,
@@ -504,7 +509,7 @@ function renderViewer(
         <PdfViewer
           blobUrl={blobUrl}
           fileName={shape.fileName}
-          shapeId={shape.id}
+          shapeId={shape.sourceId}
           blobHash={shape.blobRef}
           immersive={immersive}
           onImmersiveChange={onImmersiveChange}

--- a/src/ui/FileViewerContent.tsx
+++ b/src/ui/FileViewerContent.tsx
@@ -272,10 +272,12 @@ export function FileViewerContent({
     }
   }, [blobRef]);
 
-  if (!descriptor) {
-    return null;
-  }
-
+  // No "missing file" guard here on purpose: `descriptor` is required, so this
+  // component always has something to render. The case it used to cover — the
+  // shape being deleted while its viewer is open — now belongs to
+  // `FileViewerHost`, which resolves the shape and renders nothing when the
+  // lookup comes back null. A truthiness check on a non-optional prop would read
+  // like a live safety net while being unreachable.
   const displayName = descriptor.label || descriptor.fileName;
   const FileIcon = getFileTypeLucideIcon(descriptor.fileCategory);
 

--- a/src/ui/FileViewerHost.tsx
+++ b/src/ui/FileViewerHost.tsx
@@ -1,0 +1,48 @@
+/**
+ * Mounts the file viewer for whatever is currently open (JP-495).
+ *
+ * Lives at app level, NOT inside the canvas. A collapsed canvas region gets
+ * `display: none` (`.app-main > .is-collapsed`, App.css), so a host mounted
+ * inside it would render the modal into a hidden subtree — invisible. That is
+ * exactly the state a prose chip is usually clicked from: Relaxed → Write focus
+ * hides the canvas. (`FloatingFileViewer` would have survived on its own since
+ * it portals to `document.body`; the modal renders in place and would not.)
+ *
+ * Resolving the descriptor here also keeps the hook rules simple: the
+ * shape-lookup hook runs unconditionally, and only the render branches.
+ */
+
+import { useSessionStore } from '../store/sessionStore';
+import { useMobileAdaptation } from './layout/useMobileAdaptation';
+import { resolveViewerMode } from './fileViewerMode';
+import { useFileShapeDescriptor } from './useFileShapeDescriptor';
+import { FileViewerModal } from './FileViewerModal';
+import { FloatingFileViewer } from './FloatingFileViewer';
+
+export function FileViewerHost() {
+  const viewingFile = useSessionStore((s) => s.viewingFile);
+  const closeFileViewer = useSessionStore((s) => s.closeFileViewer);
+  const fileViewerMode = useSessionStore((s) => s.fileViewerMode);
+  const { mobileActive } = useMobileAdaptation();
+
+  // Unconditional — hooks can't be called inside a branch. An empty id resolves
+  // to null, which is also the right answer when nothing is open.
+  const shapeDescriptor = useFileShapeDescriptor(
+    viewingFile?.source === 'shape' ? viewingFile.shapeId : '',
+  );
+
+  if (!viewingFile) return null;
+
+  const descriptor =
+    viewingFile.source === 'shape' ? shapeDescriptor : viewingFile.descriptor;
+
+  // The shape was deleted while its viewer was open — close rather than render
+  // an empty frame.
+  if (!descriptor) return null;
+
+  return resolveViewerMode(fileViewerMode, mobileActive) === 'floating' ? (
+    <FloatingFileViewer descriptor={descriptor} onClose={closeFileViewer} />
+  ) : (
+    <FileViewerModal descriptor={descriptor} onClose={closeFileViewer} />
+  );
+}

--- a/src/ui/FileViewerModal.tsx
+++ b/src/ui/FileViewerModal.tsx
@@ -9,21 +9,22 @@ import { PictureInPicture2 } from 'lucide-react';
 import { Icon } from './icons';
 import { useSessionStore } from '../store/sessionStore';
 import { useMobileAdaptation } from './layout/useMobileAdaptation';
-import { FileViewerContent, useFileShape } from './FileViewerContent';
+import { FileViewerContent } from './FileViewerContent';
+import type { FileDescriptor } from './fileDescriptor';
 import './FileViewerModal.css';
 
 export interface FileViewerModalProps {
-  shapeId: string;
+  descriptor: FileDescriptor;
   onClose: () => void;
 }
 
-export function FileViewerModal({ shapeId, onClose }: FileViewerModalProps) {
+export function FileViewerModal({ descriptor, onClose }: FileViewerModalProps) {
   // Immersive reading (PDF): the modal owns it because it's the modal's own
   // chrome (header, rounded frame) that collapses alongside the viewer's.
   const [immersive, setImmersive] = useState(false);
   const { mobileActive } = useMobileAdaptation();
   const setFileViewerMode = useSessionStore((s) => s.setFileViewerMode);
-  const fileShape = useFileShape(shapeId);
+
 
   // Escape: exit immersive first, close second. (The PDF reader's find bar
   // handles its own Escape and stops propagation before this window listener.)
@@ -49,7 +50,7 @@ export function FileViewerModal({ shapeId, onClose }: FileViewerModalProps) {
     [onClose]
   );
 
-  if (!fileShape) {
+  if (!descriptor) {
     return null;
   }
 
@@ -61,7 +62,7 @@ export function FileViewerModal({ shapeId, onClose }: FileViewerModalProps) {
     <div className={overlayClass} onClick={handleOverlayClick}>
       <div className="file-viewer-modal">
         <FileViewerContent
-          shapeId={shapeId}
+          descriptor={descriptor}
           onClose={onClose}
           immersive={immersive}
           onImmersiveChange={setImmersive}

--- a/src/ui/FloatingFileViewer.tsx
+++ b/src/ui/FloatingFileViewer.tsx
@@ -20,11 +20,12 @@ import {
   resolveViewerPanelBounds,
   type PanelBounds,
 } from './floatingPosition';
-import { FileViewerContent, useFileShape } from './FileViewerContent';
+import { FileViewerContent } from './FileViewerContent';
+import type { FileDescriptor } from './fileDescriptor';
 import './FloatingFileViewer.css';
 
 export interface FloatingFileViewerProps {
-  shapeId: string;
+  descriptor: FileDescriptor;
   onClose: () => void;
 }
 
@@ -40,8 +41,8 @@ function viewportSize() {
   return { w: window.innerWidth, h: window.innerHeight };
 }
 
-export function FloatingFileViewer({ shapeId, onClose }: FloatingFileViewerProps) {
-  const fileShape = useFileShape(shapeId);
+export function FloatingFileViewer({ descriptor, onClose }: FloatingFileViewerProps) {
+
   const setFileViewerMode = useSessionStore((s) => s.setFileViewerMode);
   const storedBounds = useUIPreferencesStore((s) => s.floatingViewerBounds);
   const setStoredBounds = useUIPreferencesStore((s) => s.setFloatingViewerBounds);
@@ -124,7 +125,7 @@ export function FloatingFileViewer({ shapeId, onClose }: FloatingFileViewerProps
     [onClose],
   );
 
-  if (!fileShape) {
+  if (!descriptor) {
     return null;
   }
 
@@ -138,11 +139,11 @@ export function FloatingFileViewer({ shapeId, onClose }: FloatingFileViewerProps
         height: `${bounds.h}px`,
       }}
       role="complementary"
-      aria-label={`File viewer: ${fileShape.fileName}`}
+      aria-label={`File viewer: ${descriptor.fileName}`}
       onKeyDown={handleKeyDown}
     >
       <FileViewerContent
-        shapeId={shapeId}
+        descriptor={descriptor}
         onClose={onClose}
         headerPointerDown={(e) => beginGesture(e, 'move')}
         headerExtras={

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -587,9 +587,9 @@
 .tiptap-editor .ProseMirror .file-ref {
   display: inline-flex;
   align-items: baseline;
-  gap: 0.35em;
+  gap: 0.3em;
   max-width: 100%;
-  padding: 0.05em 0.45em;
+  padding: 0.05em 0.2em 0.05em 0.45em;
   border: 1px solid var(--border-color);
   /* --radius-full is 50% (an ellipse on a non-square box) — a pill needs the
      999px token. See the radius-full-is-ellipse note. */
@@ -605,9 +605,12 @@
   background-color: var(--bg-tertiary);
 }
 
+.tiptap-editor .ProseMirror .file-ref:focus-visible {
+  outline: 2px solid var(--accent-color, currentColor);
+  outline-offset: 1px;
+}
+
 .tiptap-editor .ProseMirror .file-ref .file-ref-icon {
-  width: 1em;
-  height: 1em;
   flex: 0 0 auto;
   /* Nudge the icon onto the text baseline rather than the box baseline. */
   transform: translateY(0.15em);
@@ -615,9 +618,9 @@
 
 .tiptap-editor .ProseMirror .file-ref .file-ref-name {
   overflow: hidden;
+  /* The name is middle-truncated in JS so the extension survives; this is only
+     a backstop for a container narrower than the budget. */
   text-overflow: ellipsis;
-  /* Shrink the NAME, never the size badge — a truncated size reads as wrong
-     data, whereas a truncated filename reads as truncated. */
   min-width: 0;
 }
 
@@ -626,6 +629,55 @@
   color: var(--text-muted, var(--text-secondary));
   font-size: 0.85em;
   font-variant-numeric: tabular-nums;
+}
+
+/* Download rides along inside the chip: revealed on hover/focus so the common
+   case (get the file) doesn't require opening the viewer first. Space is
+   reserved either way, so revealing it never reflows the line. */
+.tiptap-editor .ProseMirror .file-ref .file-ref-download {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1em;
+  border: none;
+  border-radius: var(--radius-pill, 999px);
+  background: transparent;
+  color: inherit;
+  opacity: 0;
+  cursor: pointer;
+  transform: translateY(0.1em);
+}
+
+.tiptap-editor .ProseMirror .file-ref:hover .file-ref-download,
+.tiptap-editor .ProseMirror .file-ref:focus-visible .file-ref-download,
+.tiptap-editor .ProseMirror .file-ref .file-ref-download:focus-visible {
+  opacity: 0.75;
+}
+
+.tiptap-editor .ProseMirror .file-ref .file-ref-download:hover {
+  opacity: 1;
+  background: var(--bg-primary);
+}
+
+/* Unavailable: the bytes aren't here, so the chip must not look clickable in
+   the same way. Same vocabulary as `.field-ref-unset` — muted + dashed — so the
+   inline atoms read as one system. */
+.tiptap-editor .ProseMirror .file-ref.file-ref-missing {
+  color: var(--text-secondary, rgba(127, 127, 127, 0.9));
+  background-color: transparent;
+  border-style: dashed;
+}
+
+.tiptap-editor .ProseMirror .file-ref.file-ref-busy {
+  cursor: progress;
+  opacity: 0.7;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .tiptap-editor .ProseMirror .file-ref,
+  .tiptap-editor .ProseMirror .file-ref .file-ref-download {
+    transition: background-color 0.12s ease, opacity 0.12s ease;
+  }
 }
 
 .tiptap-editor .ProseMirror .bibliography-block {

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -51,6 +51,7 @@ import { Callout } from '../tiptap/CalloutExtension';
 import { CodeBlock } from '../tiptap/CodeBlockExtension';
 import { Figure, Figcaption } from '../tiptap/FigureExtension';
 import { Gallery } from '../tiptap/GalleryExtension';
+import { handleProseFileDrop } from '../tiptap/proseDropGuard';
 import { handleCitationDoiPaste } from '../tiptap/citationPaste';
 import { isProjectionTransaction } from '../tiptap/proseProjection';
 import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
@@ -339,6 +340,9 @@ export function TiptapEditor({ className, onEditorReady }: TiptapEditorProps) {
       },
       // Paste a bare DOI → resolve + add to the library + insert a citation.
       handlePaste: (view, event) => handleCitationDoiPaste(view, event),
+      // Swallow file drops — the browser's default is to navigate away to the
+      // dropped file, discarding unsaved editor state (JP-495).
+      handleDrop: (view, event) => handleProseFileDrop(view, event as DragEvent),
     },
   });
 

--- a/src/ui/fileDescriptor.test.ts
+++ b/src/ui/fileDescriptor.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The descriptor is the one boundary both file hosts pass through (JP-495), so
+ * it is where the two blob-reference forms have to be reconciled: a canvas
+ * `FileShape` stores a **bare hash**, a prose chip stores the **`blob://<hash>`
+ * URI**. Getting that wrong doesn't throw — it produces a viewer that silently
+ * fails to load, or a reference the blob walk can't see.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { toBlobHash, describeFileShape } from './fileDescriptor';
+import type { FileShape, Shape } from '../shapes/Shape';
+
+const HASH = 'a'.repeat(64);
+
+function fileShape(overrides: Partial<FileShape> = {}): Shape {
+  return {
+    id: 'shape-1',
+    type: 'file',
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    rotation: 0,
+    blobRef: HASH,
+    fileName: 'report.pdf',
+    mimeType: 'application/pdf',
+    fileSize: 2048,
+    fileCategory: 'pdf',
+    ...overrides,
+  } as unknown as Shape;
+}
+
+describe('toBlobHash', () => {
+  it('passes a bare hash through', () => {
+    expect(toBlobHash(HASH)).toBe(HASH);
+  });
+
+  it('strips the blob:// URI form', () => {
+    expect(toBlobHash(`blob://${HASH}`)).toBe(HASH);
+  });
+
+  it('never yields a double-prefixed value', () => {
+    // The failure this guards: a caller that prefixes an already-prefixed ref.
+    // A single `startsWith` strip would leave `blob://<hash>` and the blob would
+    // simply never resolve, with nothing reporting why.
+    expect(toBlobHash(`blob://blob://${HASH}`)).toBe(HASH);
+    expect(toBlobHash(`blob://blob://blob://${HASH}`)).toBe(HASH);
+  });
+
+  it('leaves an empty ref empty rather than inventing one', () => {
+    expect(toBlobHash('')).toBe('');
+    expect(toBlobHash('blob://')).toBe('');
+  });
+});
+
+describe('describeFileShape', () => {
+  it('describes a file shape', () => {
+    const d = describeFileShape(fileShape());
+    expect(d).toMatchObject({
+      blobRef: HASH,
+      fileName: 'report.pdf',
+      mimeType: 'application/pdf',
+      fileSize: 2048,
+      fileCategory: 'pdf',
+      sourceId: 'shape-1',
+    });
+  });
+
+  it('normalizes a shape whose blobRef carries the URI form', () => {
+    // Shapes store bare hashes today, but a prefixed value must still resolve
+    // rather than producing a viewer stuck on "not found".
+    const d = describeFileShape(fileShape({ blobRef: `blob://${HASH}` } as Partial<FileShape>));
+    expect(d?.blobRef).toBe(HASH);
+  });
+
+  it('carries the stored category rather than re-deriving it', () => {
+    // Deriving here would silently change which viewer opens for any shape
+    // whose stored category disagrees with its mime.
+    const d = describeFileShape(
+      fileShape({ fileCategory: 'generic', mimeType: 'application/pdf' } as Partial<FileShape>),
+    );
+    expect(d?.fileCategory).toBe('generic');
+  });
+
+  it('returns null for a missing or non-file shape', () => {
+    expect(describeFileShape(undefined)).toBeNull();
+    expect(describeFileShape({ id: 'r1', type: 'rectangle' } as unknown as Shape)).toBeNull();
+  });
+
+  it('attaches host capabilities when given, and none otherwise', () => {
+    // Absent capabilities are what make the viewer HIDE replace/recover for a
+    // prose chip instead of offering an action with nowhere to write back to.
+    const plain = describeFileShape(fileShape());
+    expect(plain?.onReplace).toBeUndefined();
+    expect(plain?.onRecover).toBeUndefined();
+
+    const capable = describeFileShape(fileShape(), {
+      onReplace: async () => true,
+      onRecover: async () => true,
+    });
+    expect(typeof capable?.onReplace).toBe('function');
+    expect(typeof capable?.onRecover).toBe('function');
+  });
+});

--- a/src/ui/fileDescriptor.ts
+++ b/src/ui/fileDescriptor.ts
@@ -1,0 +1,107 @@
+/**
+ * What the file viewer needs to show a file, independent of where the file
+ * lives (JP-495).
+ *
+ * The viewer used to take a canvas `shapeId` and look the shape up itself. A
+ * prose file chip has no shape, and building a second prose-only viewer is the
+ * *second-renderer defect class* that produced JP-468/472/473 — so instead both
+ * hosts describe their file the same way and there stays exactly one viewer.
+ *
+ * The viewer is not read-only: it can replace a file's contents and recover a
+ * missing blob. Those are host-specific mutations, so they arrive as optional
+ * callbacks rather than being reachable from the data. **Absent means the host
+ * cannot do it, and the affordance is hidden** — not shown-but-broken.
+ */
+
+import { isFile, type Shape } from '../shapes/Shape';
+import type { FileCategory } from '../utils/fileUtils';
+
+/** Prefix of the `blob://<hash>` URI form used inside prose HTML. */
+const BLOB_PREFIX = 'blob://';
+
+/**
+ * Reduce either reference form to the bare hash the blob store is keyed by.
+ *
+ * The two forms are not interchangeable and the difference is easy to miss: a
+ * `FileShape` stores a **bare hash**, while a prose chip stores the
+ * **`blob://<hash>` URI** (it has to — a reference inside an HTML string is only
+ * discoverable by the URI grammar, JP-494). Normalizing here, at the one
+ * boundary both hosts pass through, is what stops a `blob://blob://…` from ever
+ * being constructed.
+ *
+ * **Not** the same as `blobHashFromRef` (`storage/blobResolver.ts`), which
+ * returns `null` for a bare hash because it is distinguishing a `blob://` ref
+ * from a directly-loadable URL. This one accepts either form and always yields a
+ * hash — do not "consolidate" the two.
+ */
+export function toBlobHash(ref: string): string {
+  let out = ref;
+  // A loop, not a single strip: a value that was prefixed twice by an earlier
+  // bug should still resolve rather than silently failing to load.
+  while (out.startsWith(BLOB_PREFIX)) out = out.slice(BLOB_PREFIX.length);
+  return out;
+}
+
+export interface FileDescriptor {
+  /** Bare SHA-256 hash — always run the source through `toBlobHash`. */
+  blobRef: string;
+  fileName: string;
+  mimeType: string;
+  fileSize: number;
+  /**
+   * Drives viewer dispatch. Carried rather than always re-derived so a canvas
+   * shape keeps using the category it stored — deriving it here instead would
+   * silently change which viewer opens for any shape whose stored category and
+   * mime disagree. Prose has nothing stored, so it derives with
+   * `detectFileCategory` (JP-495 keeps the category out of the chip's attrs
+   * precisely so it can never drift from the mime).
+   */
+  fileCategory: FileCategory;
+  /**
+   * Stable key for per-file view state (PDF reading position + bookmarks),
+   * scoped to the document by `PdfViewer`. A canvas shape uses its shape id, so
+   * two shapes of the same PDF keep separate positions. Prose passes the blob
+   * hash instead: a chip has no durable id of its own, and "the same attachment
+   * resumes where I left it" is the behaviour a reader expects anyway.
+   * Optional — `PdfViewer` simply stops persisting when it is absent.
+   */
+  sourceId?: string | undefined;
+  /** Display name override; falls back to `fileName`. */
+  label?: string | undefined;
+  preview?: { pageCount?: number | undefined } | undefined;
+  /**
+   * Swap the file's contents for `file`. Absent ⇒ the host has nowhere to write
+   * the new reference, so the Replace affordance is not rendered.
+   */
+  onReplace?: ((file: File) => Promise<boolean>) | undefined;
+  /**
+   * Re-upload the bytes for a blob that has gone missing. Absent ⇒ the recovery
+   * affordance is not rendered, and the viewer just reports the file missing.
+   */
+  onRecover?: ((file: File) => Promise<boolean>) | undefined;
+}
+
+/**
+ * Describe a canvas `FileShape`. Returns null for a shape that is absent or not
+ * a file, matching the old `useFileShape` contract.
+ *
+ * Capabilities are supplied by the caller because they need the services layer,
+ * which this module deliberately does not depend on.
+ */
+export function describeFileShape(
+  shape: Shape | undefined,
+  capabilities?: Pick<FileDescriptor, 'onReplace' | 'onRecover'>,
+): FileDescriptor | null {
+  if (!shape || !isFile(shape)) return null;
+  return {
+    blobRef: toBlobHash(shape.blobRef),
+    fileName: shape.fileName,
+    mimeType: shape.mimeType,
+    fileSize: shape.fileSize,
+    fileCategory: shape.fileCategory,
+    sourceId: shape.id,
+    label: shape.label,
+    preview: shape.preview,
+    ...capabilities,
+  };
+}

--- a/src/ui/proseFileUpload.ts
+++ b/src/ui/proseFileUpload.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared prose-file upload pipeline (JP-495).
+ *
+ * The file counterpart of `proseImageUpload.ts`: persist a picked File to
+ * content-addressed blob storage and hand back the attributes a `fileRef` chip
+ * needs. There is no processing step — an attachment is stored byte-for-byte,
+ * unlike an image, which gets validated and downscaled.
+ *
+ * The quota check is the gate images get for free from `processImageForUpload`
+ * (which enforces `MAX_FILE_SIZE`). A raw attachment has no such ceiling, so
+ * without this a single large file could fill IndexedDB. `hasSpaceForBlob` is
+ * the same gate the canvas import path uses (`FileImportService`) — quota-aware
+ * rather than a fixed cap, so prose and canvas can't disagree about what fits.
+ */
+
+import { blobStorage } from '../storage/BlobStorage';
+import { hasSpaceForBlob } from '../storage/StorageQuotaMonitor';
+import type { FileRefAttrs } from '../tiptap/FileRefExtension';
+
+export class ProseFileQuotaError extends Error {
+  constructor() {
+    super('Not enough local storage space for this file.');
+    this.name = 'ProseFileQuotaError';
+  }
+}
+
+/**
+ * Store `file` and return the chip attributes for it.
+ *
+ * `blobRef` comes back in the **`blob://<hash>` URI form**, not a bare hash: the
+ * attribute is serialized inside an HTML string, and only that grammar is
+ * discoverable by the blob reference walk. Storing a bare hash would leave the
+ * blob invisible to refcounting, the publish manifest, and the MCP file tools —
+ * none of which fail loudly (JP-494).
+ */
+export async function uploadProseFile(file: File): Promise<FileRefAttrs> {
+  if (!(await hasSpaceForBlob(file.size))) {
+    throw new ProseFileQuotaError();
+  }
+
+  const blobId = await blobStorage.saveBlob(file, file.name);
+
+  return {
+    blobRef: `blob://${blobId}`,
+    fileName: file.name,
+    // A browser leaves `type` empty for unknown extensions; the chip and viewer
+    // both fall back to filename-based detection, so an empty string is a
+    // truthful "unknown" rather than a guess.
+    mimeType: file.type,
+    fileSize: String(file.size),
+  };
+}

--- a/src/ui/useFileShapeDescriptor.ts
+++ b/src/ui/useFileShapeDescriptor.ts
@@ -1,0 +1,29 @@
+/**
+ * Describe a canvas `FileShape` for the file viewer (JP-495).
+ *
+ * This is where the canvas's *capabilities* get attached: replacing a file's
+ * contents and recovering a missing blob both write back to the shape, so they
+ * live here rather than in `fileDescriptor.ts` (which stays free of the services
+ * layer). A host without these — prose — simply omits them, and the viewer hides
+ * the affordances instead of offering an action that cannot work.
+ */
+
+import { useMemo } from 'react';
+
+import { useDocumentStore } from '../store/documentStore';
+import { replaceFileContents, reuploadMissingBlob } from '../services/FileReplaceService';
+import { describeFileShape, type FileDescriptor } from './fileDescriptor';
+
+/** `null` when the shape is absent or isn't a file — same contract as `useFileShape`. */
+export function useFileShapeDescriptor(shapeId: string): FileDescriptor | null {
+  const shape = useDocumentStore((state) => state.shapes[shapeId]);
+
+  return useMemo(
+    () =>
+      describeFileShape(shape, {
+        onReplace: async (file: File) => (await replaceFileContents(shapeId, file)).success,
+        onRecover: async (file: File) => (await reuploadMissingBlob(shapeId, file)).success,
+      }),
+    [shape, shapeId],
+  );
+}

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -207,3 +207,31 @@ export function sanitizeFileName(name: string): string {
 
   return sanitized || 'Untitled';
 }
+
+/**
+ * Shorten a filename for a tight display slot, keeping the **extension**.
+ *
+ * Plain CSS ellipsis truncates the tail, which throws away the single most
+ * informative part of a filename — `quarterly-report-final-v3.pdf` becomes
+ * `quarterly-repo…`, and the reader can no longer tell a PDF from a ZIP. This
+ * truncates the stem instead: `quarterly-report-final-….pdf`.
+ *
+ * Uses the same "is that really an extension" heuristic as `sanitizeFileName`
+ * (a dot that isn't leading, within 10 chars of the end) so the two agree about
+ * what a filename's parts are.
+ */
+export function truncateFileNameForDisplay(name: string, maxLength = 28): string {
+  if (name.length <= maxLength) return name;
+
+  const dot = name.lastIndexOf('.');
+  const hasExt = dot > 0 && name.length - dot <= 10;
+  const ext = hasExt ? name.slice(dot) : '';
+
+  // No room for a stem worth reading — fall back to a tail cut rather than
+  // returning something that is almost entirely extension.
+  if (ext.length + 2 >= maxLength) return `${name.slice(0, maxLength - 1)}…`;
+
+  const stem = hasExt ? name.slice(0, dot) : name;
+  const keep = maxLength - ext.length - 1; // -1 for the ellipsis
+  return `${stem.slice(0, keep)}…${ext}`;
+}

--- a/src/utils/pdfExportUtils.ts
+++ b/src/utils/pdfExportUtils.ts
@@ -18,6 +18,7 @@ import {
   getPageDimensions,
 } from '../types/PDFExport';
 import { blobStorage } from '../storage/BlobStorage';
+import { formatFileSize } from './byteSize';
 import { exportToPng, type ExportData } from './exportUtils';
 import { useDocumentStore } from '../store/documentStore';
 import { isGroup, type GroupShape, type Shape, type ConnectorShape } from '../shapes/Shape';
@@ -1467,6 +1468,19 @@ export function extractSegments(node: JSONContent): TextSegment[] {
           color: null, highlight: null, fontSizeScale: 1, yOffset: 0,
         });
       }
+    } else if (child.type === 'fileRef') {
+      // Inline file chip (JP-495). A PDF can't carry the attachment, but it must
+      // not silently drop the fact that one is referenced — a reader of the
+      // export would have no idea a file was ever there. Name + size is the
+      // honest static rendering, matching how the other inline atoms degrade.
+      const name = (child.attrs?.['fileName'] as string | undefined) || 'Attachment';
+      const rawSize = Number(child.attrs?.['fileSize'] ?? 0);
+      const size = Number.isFinite(rawSize) && rawSize > 0 ? ` (${formatFileSize(rawSize)})` : '';
+      segments.push({
+        text: `${name}${size}`,
+        bold: false, italic: true, underline: false, strike: false, code: false,
+        color: null, highlight: null, fontSizeScale: 1, yOffset: 0,
+      });
     }
     // Skip other non-text inline nodes (mathInline handled separately at block level)
   }
@@ -2164,7 +2178,15 @@ function extractSegmentsDeep(node: JSONContent): TextSegment[] {
   // If this node has inline text (or inline citation / field) children directly, extract them
   if (
     node.content &&
-    node.content.some((c) => c.type === 'text' || c.type === 'citationInline' || c.type === 'fieldRef')
+    node.content.some(
+      (c) =>
+        c.type === 'text' ||
+        c.type === 'citationInline' ||
+        c.type === 'fieldRef' ||
+        // A paragraph holding ONLY a file chip still has content to render;
+        // without this it is treated as empty and skipped entirely.
+        c.type === 'fileRef',
+    )
   ) {
     return extractSegments(node);
   }

--- a/src/utils/truncateFileName.test.ts
+++ b/src/utils/truncateFileName.test.ts
@@ -1,0 +1,48 @@
+/**
+ * JP-495: a filename in a chip is truncated in the MIDDLE so the extension
+ * survives. Tail truncation (what CSS ellipsis does) turns
+ * `quarterly-report-final-v3.pdf` into `quarterly-repo…`, throwing away the one
+ * part that tells a reader what the file actually is.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { truncateFileNameForDisplay } from './fileUtils';
+
+describe('truncateFileNameForDisplay', () => {
+  it('leaves a short name alone', () => {
+    expect(truncateFileNameForDisplay('notes.txt', 28)).toBe('notes.txt');
+  });
+
+  it('keeps the extension when it truncates', () => {
+    const out = truncateFileNameForDisplay('quarterly-report-final-v3.pdf', 28);
+    expect(out.endsWith('.pdf')).toBe(true);
+    expect(out).toContain('…');
+    expect(out.length).toBeLessThanOrEqual(28);
+    expect(out.startsWith('quarterly-report')).toBe(true);
+  });
+
+  it('never exceeds the budget', () => {
+    for (const n of [10, 16, 28, 40]) {
+      expect(truncateFileNameForDisplay('a'.repeat(120) + '.tar.gz', n).length).toBeLessThanOrEqual(n);
+    }
+  });
+
+  it('tail-truncates a name with no extension', () => {
+    const out = truncateFileNameForDisplay('a'.repeat(60), 20);
+    expect(out.length).toBeLessThanOrEqual(20);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('does not treat a long trailing segment as an extension', () => {
+    // Matches sanitizeFileName's heuristic: a dot within 10 chars of the end.
+    // Otherwise `archive.2026-annual-report` would be "preserved" whole.
+    const out = truncateFileNameForDisplay('archive.2026-annual-reporting', 20);
+    expect(out.length).toBeLessThanOrEqual(20);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('does not mistake a leading dot for an extension', () => {
+    const out = truncateFileNameForDisplay('.' + 'b'.repeat(50), 20);
+    expect(out.length).toBeLessThanOrEqual(20);
+  });
+});


### PR DESCRIPTION
Second slice of JP-495, on top of #453 (now on `master`).

The node landed in #453, but a writer couldn't use it: no Insert affordance, no slash command, and the chip rendered with a **blank icon slot** — the node view built its DOM by hand while `getFileTypeLucideIcon` returns a React component, so it created an empty `<svg>` and never drew into it.

## The viewer takes a descriptor, not a shape id

A prose chip has no shape, and a second prose-only viewer is the defect class that produced JP-468/472/473.

The wrinkle: **the viewer isn't read-only.** It can replace a file's contents and recover a missing blob. So the descriptor carries optional capability callbacks — *absent means the host cannot do it and the affordance is hidden*, not shown-and-broken.

| | Canvas | Prose |
|---|---|---|
| Replace button | present | **hidden** |
| Re-upload on missing blob | present | **hidden**, and the copy drops its "re-upload to restore it" promise |

Both confirmed live in the browser, not just reasoned about.

Two details worth review: `fileCategory` is **carried, not re-derived** (deriving would silently change which viewer opens for any shape whose stored category disagrees with its mime), and `sourceId` keys PDF reading position — shape id for canvas, blob hash for prose, since a chip has no durable id and "the same attachment resumes where I left it" is what a reader expects.

## A correction to the approved plan

The plan said the viewer host needed no lift because `FloatingFileViewer` portals. **`FileViewerModal` doesn't**, and a collapsed canvas region gets `display: none` (`.app-main > .is-collapsed`). So in Relaxed → Write — exactly where prose is read — clicking a chip would have opened *nothing* in modal mode. The host is now `FileViewerHost`, sitting with `ConfirmDialogHost` and the other app-level hosts.

`sessionStore.viewingFileShapeId` becomes a `viewingFile` union; a parallel "prose file" field would have been a second source of truth for one exclusive piece of UI state.

## Two things found while building, neither in scope

- **Dropping a file on prose was destructive.** No `handleDrop` existed, so the browser default — navigate away to the file — discarded unsaved editor state. Now guarded, and **shared between both prose editors**: wiring it into one would have left `CollaborativeProseEditor` destructive with nothing to say so.
- **PDF export dropped chips silently.** Only `image` nodes were embedded, and a paragraph containing *only* a chip was treated as empty and skipped entirely.

## UX decisions worth naming

- **Middle-truncation**, so the extension survives: `quarterly-report-final-….pdf`. Tail truncation throws away the one part that says what the file is.
- **The chip reports state.** An unavailable blob is muted + dashed rather than looking clickable — same vocabulary as `.field-ref-unset`.
- `role="button"` + Enter/Space. An inline atom with only a click handler is unreachable without a mouse.
- Download on hover, so the common case skips the viewer.

## Verification

Local stack, including **real user-supplied files** (a 3.3 MB PDF and an SVG, which correctly resolve to different icons): insert → chip, click-to-open, keyboard activation, drop guard (`defaultPrevented: true`, prose unchanged), and the capability contrast above.

- `bun run test --run` — 3572 passed (300 files)
- `cargo test --manifest-path relay/Cargo.toml --locked` — 26 binaries green (relay untouched)
- `tsc --noEmit` clean; OSS leak grep clean
- **Mutation-tested** each new guard — double-prefix normalization, category carry-through, extension-preserving truncation — each fails exactly one test when the behaviour is removed

Two of my probes gave false negatives before I diagnosed them: the drop test omitted `clientX/clientY` (ProseMirror resolves a drop position *before* consulting `handleDrop`), and the keyboard test checked for the viewer synchronously, before React re-rendered. Bad tests, not broken code — noting it because "the guard didn't fire" was my first reading in both cases.

## Still out of scope

Drag-drop/paste **insert** (only the destructive-drop guard is here), replace/recover *from* a prose chip (the descriptor supports it; no host wiring), and the Notion connector emitting `fileRef` — which is what actually closes the original attachment-import gap.

Assisted-by: Opus 5