### PR TITLE
Decode the entities a browser would (JP-497)

### DIFF
--- a/relay/Cargo.lock
+++ b/relay/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "governor",
  "hex",
  "hmac",
+ "htmlize",
  "jsonwebtoken",
  "libc",
  "local-ip-address",
@@ -799,6 +800,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "htmlize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e815d50d9e411ba2690d730e6ec139c08260dddb756df315dbd16d01a587226"
+dependencies = [
+ "memchr",
+ "pastey",
+ "phf",
+ "phf_codegen",
+ "serde_json",
 ]
 
 [[package]]
@@ -1396,6 +1410,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1439,44 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -2068,6 +2126,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -96,6 +96,16 @@ toml = "0.8"
 # heavier CommonMark stack, matching the small-dep-tree stance above.
 pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
 
+# HTML character-entity decoding for the `format:"html"` prose path (JP-497).
+# The hand-rolled table this replaced knew six names, so every other named
+# entity (`&mdash;`, `&le;`, `&aacute;`) survived as literal text and was
+# re-escaped on serialize. htmlize carries the WHATWG named-entity table and,
+# critically, distinguishes general from ATTRIBUTE context — attribute values
+# must not expand a semicolon-less entity followed by `=` or an alphanumeric,
+# which is what keeps `?a=1&sect=2` a query string rather than a section sign.
+# Pure-Rust and table-only, matching the small-dep-tree stance above.
+htmlize = { version = "1.1", default-features = false, features = ["unescape"] }
+
 # Per-workspace token-bucket rate limiting (Phase 21.3)
 governor = "0.7"
 

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -329,13 +329,13 @@ fn parse_attrs(s: &str) -> Vec<(String, String)> {
                 if i < b.len() {
                     i += 1; // closing quote
                 }
-                decode_entities(v)
+                decode_attr_entities(v)
             } else {
                 let vstart = i;
                 while i < b.len() && !b[i].is_ascii_whitespace() {
                     i += 1;
                 }
-                decode_entities(&s[vstart..i])
+                decode_attr_entities(&s[vstart..i])
             };
             attrs.push((name, value));
         } else {
@@ -345,52 +345,49 @@ fn parse_attrs(s: &str) -> Vec<(String, String)> {
     attrs
 }
 
+/// Decode character references in **text** content (WHATWG general context).
+///
+/// This replaced a hand-rolled table that knew six names — `amp`, `lt`, `gt`,
+/// `quot`, `apos`/`#39`, `nbsp` — plus numeric refs (JP-497). Every other named
+/// entity fell through to a literal `&`, which the serializer then re-escaped to
+/// `&amp;`, so `&mdash;` was stored as `&amp;mdash;` and shown to the reader as
+/// the visible string `&mdash;`. Nothing reported it: the write returned a clean
+/// `{"ok": true}`, and the corruption was only findable by reading the page back.
+///
+/// It landed almost entirely on agents. A model writing HTML reaches for
+/// `&mdash;` and `&aacute;` by reflex because HTML corpora are full of them,
+/// while a human typing in the editor produces literal Unicode and never meets
+/// this path at all.
+///
+/// The markdown path was always correct — pulldown-cmark decodes the full
+/// CommonMark entity set — so `format:"markdown"`, the default, hid the bug.
+/// Two decoders for one contract with nothing asserting they agree is the shape
+/// of JP-468/472/473; `markdown_and_html_paths_agree_on_entities` is the guard.
 fn decode_entities(s: &str) -> String {
     if !s.contains('&') {
         return s.to_string();
     }
-    let mut out = String::with_capacity(s.len());
-    let mut rest = s;
-    while let Some(amp) = rest.find('&') {
-        out.push_str(&rest[..amp]);
-        rest = &rest[amp..];
-        let Some(semi) = rest.find(';') else {
-            out.push('&');
-            rest = &rest[1..];
-            continue;
-        };
-        let entity = &rest[1..semi];
-        let decoded = match entity {
-            "amp" => Some('&'),
-            "lt" => Some('<'),
-            "gt" => Some('>'),
-            "quot" => Some('"'),
-            "apos" | "#39" => Some('\''),
-            "nbsp" => Some('\u{00a0}'),
-            _ => entity
-                .strip_prefix('#')
-                .and_then(|n| {
-                    if let Some(hex) = n.strip_prefix(['x', 'X']) {
-                        u32::from_str_radix(hex, 16).ok()
-                    } else {
-                        n.parse::<u32>().ok()
-                    }
-                })
-                .and_then(char::from_u32),
-        };
-        match decoded {
-            Some(c) => {
-                out.push(c);
-                rest = &rest[semi + 1..];
-            }
-            None => {
-                out.push('&');
-                rest = &rest[1..];
-            }
-        }
+    htmlize::unescape(s).into_owned()
+}
+
+/// Decode character references in an **attribute value** (WHATWG attribute
+/// context).
+///
+/// Deliberately not [`decode_entities`]. In attribute context a semicolon-less
+/// named entity followed by `=` or an alphanumeric is *not* expanded, which is
+/// what keeps `href="…?a=1&sect=2"` a query string instead of turning `&sect`
+/// into a section sign. Decoding attributes with general-context rules would
+/// silently corrupt URLs — see
+/// `attribute_context_preserves_legacy_url_query_strings`.
+///
+/// With the semicolon present it *is* an entity, in attributes too, exactly as a
+/// browser would treat it; that is why a literal ampersand must be written
+/// `&amp;` in HTML.
+fn decode_attr_entities(s: &str) -> String {
+    if !s.contains('&') {
+        return s.to_string();
     }
-    out.push_str(rest);
-    out
+    htmlize::unescape_attribute(s).into_owned()
 }
 
 // ---- HTML tree ------------------------------------------------------------
@@ -1529,4 +1526,114 @@ mod tests {
             assert_no_newline(n);
         }
     }
+
+    // ---- HTML5 named character entities (JP-497) ----
+    //
+    // `format:"html"` decoded only six names plus numeric refs, so every other
+    // named entity survived as literal text and was then re-escaped on
+    // serialize (`&mdash;` stored as `&amp;mdash;`). Agents reach for named
+    // entities by reflex because HTML corpora are full of them, so the failure
+    // landed hardest on the MCP surface.
+
+    /// Concatenated text of a block's direct text children.
+    fn text_of(blocks: &[PmNode]) -> String {
+        blocks
+            .iter()
+            .flat_map(|b| b.children.iter())
+            .filter_map(|c| match c {
+                PmChild::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn named_entities_decode_in_text() {
+        for (src, want) in [
+            ("&mdash;", "\u{2014}"),
+            ("&ndash;", "\u{2013}"),
+            ("&le;", "\u{2264}"),
+            ("&sect;", "\u{00a7}"),
+            ("&aacute;", "\u{00e1}"),
+            ("&copy;", "\u{00a9}"),
+            ("&hellip;", "\u{2026}"),
+            ("&rsquo;", "\u{2019}"),
+        ] {
+            let b = html_to_blocks(&format!("<p>{src}</p>"));
+            assert_eq!(text_of(&b), want, "named entity {src} must decode");
+        }
+    }
+
+    #[test]
+    fn numeric_and_predefined_entities_keep_decoding() {
+        // These already worked; pin them so the swap to a spec decoder can't
+        // regress the half that was correct.
+        for (src, want) in [
+            ("&#275;", "\u{0113}"),
+            ("&#x2014;", "\u{2014}"),
+            ("&amp;", "&"),
+            ("&lt;", "<"),
+            ("&gt;", ">"),
+            ("&quot;", "\""),
+            ("&apos;", "'"),
+            ("&nbsp;", "\u{00a0}"),
+        ] {
+            let b = html_to_blocks(&format!("<p>{src}</p>"));
+            assert_eq!(text_of(&b), want, "entity {src} must still decode");
+        }
+    }
+
+    #[test]
+    fn named_entities_decode_in_attribute_values() {
+        // The same decoder serves attribute values, so `data-label`, `alt`,
+        // `data-file-name` and `data-bib-html` corrupted identically. Not part
+        // of the original report — found by probe.
+        let b = html_to_blocks(
+            r#"<p><span data-citation data-ref-id="r" data-label="(A &mdash; B)">x</span></p>"#,
+        );
+        let PmChild::Node(c) = &b[0].children[0] else { panic!("expected citation node") };
+        assert_eq!(attr(c, "label"), Some("(A \u{2014} B)"));
+    }
+
+    #[test]
+    fn attribute_context_preserves_legacy_url_query_strings() {
+        // WHATWG's attribute rule: a semicolon-less named entity followed by
+        // `=` or an alphanumeric is NOT expanded. That is what keeps `&sect=2`
+        // a query parameter instead of a section sign. This guards the choice
+        // of attribute-context decoding — using general-context decoding for
+        // attributes would silently corrupt hrefs.
+        let b = html_to_blocks(r#"<p><a href="https://x.test/?a=1&sect=2">go</a></p>"#);
+        let PmChild::Text { marks, .. } = &b[0].children[0] else { panic!("expected text") };
+        assert_eq!(marks[0].href.as_deref(), Some("https://x.test/?a=1&sect=2"));
+    }
+
+    #[test]
+    fn attribute_entity_with_semicolon_does_decode() {
+        // The other direction, and deliberate: with the semicolon it IS an
+        // entity, in attributes too. A browser does the same, which is why a
+        // literal ampersand in HTML must be written `&amp;`.
+        let b = html_to_blocks(r#"<p><a href="https://x.test/?a=1&sect;b">go</a></p>"#);
+        let PmChild::Text { marks, .. } = &b[0].children[0] else { panic!("expected text") };
+        assert_eq!(marks[0].href.as_deref(), Some("https://x.test/?a=1\u{00a7}b"));
+    }
+
+    #[test]
+    fn markdown_and_html_paths_agree_on_entities() {
+        // The durable half. Two entity decoders — pulldown-cmark's on the
+        // markdown path and ours on the html path — with nothing asserting they
+        // agree is precisely how the second-renderer defects (JP-468/472/473)
+        // happened. pulldown-cmark was already correct here, which is why the
+        // default format hid this bug for so long.
+        for src in ["a &mdash; b", "x &le; y", "caf&eacute;", "&#275; and &copy;"] {
+            let via_markdown =
+                html_to_blocks(&crate::mcp::tools::markdown_to_html_for_tests(src));
+            let via_html = html_to_blocks(&format!("<p>{src}</p>"));
+            assert_eq!(
+                text_of(&via_markdown),
+                text_of(&via_html),
+                "markdown and html paths disagree on {src}"
+            );
+        }
+    }
+
 }

--- a/relay/tests/prose-fixtures/cases.json
+++ b/relay/tests/prose-fixtures/cases.json
@@ -506,6 +506,43 @@
           "type": "image"
         }
       ]
+    },
+    {
+      "name": "unicode_punctuation_round_trips_in_text",
+      "why": "The canonical stored form of a named entity is the decoded character, so these are the bytes that must survive a round trip on BOTH sides once JP-497 made the html path decode `&mdash;`/`&le;`/`&sect;` at all. This case cannot catch the decode bug itself (a non-canonical input is by definition not a fixed point, which is what the Rust unit tests in prose_parse cover) — it guards the other half: that neither implementation re-escapes or mangles the decoded character afterwards.",
+      "html": "<p>Ranges 1–10 — see §2 for the café ≤ limit.</p>",
+      "nodes": [
+        {
+          "type": "paragraph"
+        }
+      ]
+    },
+    {
+      "name": "unicode_in_attribute_value_round_trips",
+      "why": "Attribute values run through the same entity decoder as text (JP-497 found the corruption reached `data-label`, `alt`, `data-file-name` and `data-bib-html`, which the original report had not covered). A decoded character living in an attribute must survive both the relay's escape_attr and the client's parseHTML — the attrs are compared cross-language here, so a side that re-escapes or drops it fails loudly.",
+      "html": "<p>see <span data-citation data-ref-id=\"reamer2024\" data-label=\"(Reamer, 2024) §4\">(Reamer, 2024) §4</span> here</p>",
+      "nodes": [
+        {
+          "type": "paragraph"
+        },
+        {
+          "type": "citationInline",
+          "attrs": {
+            "label": "(Reamer, 2024) §4",
+            "refId": "reamer2024"
+          }
+        }
+      ]
+    },
+    {
+      "name": "ampersand_stays_escaped_in_canonical_form",
+      "why": "The counterpart to decoding: `&` is one of the four characters the serializer must escape, so its canonical stored form is `&amp;` and a round trip must not decode-then-emit a bare ampersand. Without this, a decoder swap could quietly start emitting raw `&` and produce stored HTML that reparses differently on the next load.",
+      "html": "<p>Fish &amp; chips &lt;yes&gt;</p>",
+      "nodes": [
+        {
+          "type": "paragraph"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Agent-reported, then reproduced by probe: `set_prose`/`add_prose_page` with `format:"html"` did not decode HTML5 named character entities. `&mdash;` survived as literal text, the serializer re-escaped the `&`, and the page stored `&amp;mdash;` — which the reader sees as the visible string `&mdash;`. The write returned a bare `{"ok": true}`, so the only way to find it was to read the page back, or to notice the artifact by eye. Which is how it was found.

## What was actually wrong

`decode_entities` was a hand-rolled table of six names (`amp`, `lt`, `gt`, `quot`, `apos`/`#39`, `nbsp`) plus numeric refs. An unrecognised name fell through to a literal `&` and advanced one byte.

It landed almost entirely on agents. A model writing HTML reaches for `&mdash;` and `&aacute;` by reflex because HTML corpora are full of them; a human typing in the editor produces literal Unicode and never touches this path.

## Two findings beyond the report

**It reached attribute values too.** The same decoder serves attributes, so `data-label`, `alt`, `data-file-name` and `data-bib-html` corrupted identically.

**It was `format:"html"` only.** pulldown-cmark already decoded the full set, so `format:"markdown"` — the default — was correct all along. That is why this survived this long, and it means the interim workaround for anyone hitting it on a deployed relay is simply to use the default format, not to avoid named entities.

Two decoders for one contract, with nothing asserting they agree, is the shape of JP-468/472/473. `markdown_and_html_paths_agree_on_entities` is the assertion that was missing.

## The fix

htmlize's WHATWG tables, split by context: `unescape` for text, `unescape_attribute` for attribute values. The attribute variant does not expand a semicolon-less entity followed by `=` or an alphanumeric, which is the only thing keeping `?a=1&sect=2` a query string instead of a section sign — decoding attributes with general-context rules would have swapped one silent corruption for another.

Dependency footprint is `htmlize` plus `phf` (a perfect-hash table for the entity set); `memchr` and `serde_json` were already in the tree. MIT OR Apache-2.0, compatible with the crate's AGPL-3.0-or-later.

## Tests, watched failing first

Six unit tests. Four fail before this change; two must **not**, and that is the point of them — numeric and predefined refs keep decoding, and the query-string case guards the choice of attribute context rather than the fix itself.

Three cases added to the cross-language corpus, pinning the other half on both the relay and the editor: the decoded character is the canonical stored form, so neither side may re-escape or mangle it afterwards.

The corpus deliberately does **not** carry the decode cases. It asserts a fixed point, and a non-canonical input is by definition not one; bending it to hold one would weaken what it asserts for every other case. The decode assertions live in `prose_parse`'s unit tests where they belong.

## Deliberate behaviour change

The old decoder required a semicolon. General context now also accepts semicolon-less named entities. Spec-correct, and pinned by test rather than left to be discovered later.

## Not done here

A `fixes` warning for a *misspelled* entity name, which still passes through silently. The obvious version reads stored content, where correctly-escaped literal text (`&amp;sect;` decodes to a literal `&sect;`) is indistinguishable from a typo and would warn wrongly. Doing it properly means scanning the input before parse — its own change, deliberately not folded in here.

## Verification

Full relay suite green: 823 lib tests plus every integration suite, no regressions. `cargo check --all-targets` clean, clippy clean. TypeScript corpus half green at 84 assertions.

Assisted-by: Opus 5