### PR TITLE
Let an agent repair a reference it got wrong (JP-498)

### DIFF
--- a/docs-site/developer/mcp-tools.md
+++ b/docs-site/developer/mcp-tools.md
@@ -168,6 +168,8 @@ icons directly — build those with `add_shape(s)`.
 | Tool | Purpose |
 | -- | -- |
 | `add_reference` | Add reference(s) to the document's library. Supply **either** `doi` (resolved via doi.org to CSL-JSON) **or** `items` (raw CSL-JSON object(s)). Dedups by DOI then id; returns the ids added + how many were skipped. |
+| `update_reference` | Repair an existing entry. `id` + `item` (CSL-JSON); fields **merge** by default (an explicit `null` clears one), `replace: true` swaps the whole item. The `id` is the library key and cannot change — renaming it would orphan every citation pointing at it. Fails on an unknown id. |
+| `delete_reference` | Remove an entry from the library and the bibliography. **Refuses while the reference is still cited inline**, naming the page/block sites and the count; `force: true` deletes anyway and leaves those citations unresolved. |
 
 This populates the **library** only — it doesn't yet insert an inline citation
 or bibliography into the prose (do that in the editor). The library is stored as

--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -164,6 +164,8 @@ icons directly — build those with `add_shape(s)`.
 | Tool | Purpose |
 | -- | -- |
 | `add_reference` | Add reference(s) to the document's library. Supply **either** `doi` (resolved via doi.org to CSL-JSON) **or** `items` (raw CSL-JSON object(s)). Dedups by DOI then id; returns the ids added + how many were skipped. |
+| `update_reference` | Repair an existing entry. `id` + `item` (CSL-JSON); fields **merge** by default (an explicit `null` clears one), `replace: true` swaps the whole item. The `id` is the library key and cannot change — renaming it would orphan every citation pointing at it. Fails on an unknown id. |
+| `delete_reference` | Remove an entry from the library and the bibliography. **Refuses while the reference is still cited inline**, naming the page/block sites and the count; `force: true` deletes anyway and leaves those citations unresolved. |
 
 This populates the **library** only — it doesn't yet insert an inline citation
 or bibliography into the prose (do that in the editor). The library is stored as

--- a/relay/src/mcp/citations.rs
+++ b/relay/src/mcp/citations.rs
@@ -228,6 +228,78 @@ pub fn add_references_in_place(doc: &mut Value, incoming: &[Value]) -> Result<Ad
     })
 }
 
+/// Replace or merge one existing CSL item in the doc's JSON library (the cold
+/// path). Returns the resulting item.
+///
+/// `merge` decides which of the two repairs a caller wanted. Merging patches
+/// named fields and leaves the rest — the common case, "this entry is missing
+/// its author". Replacing swaps the whole item, for when the original was
+/// wrong rather than incomplete. Neither touches `itemOrder`: the id is
+/// unchanged, so its display position is unchanged.
+///
+/// Refuses an unknown id rather than creating one. `add_reference` is how a
+/// reference comes into existence, and silently upserting here would turn a
+/// typo'd id into a second stranded entry — the exact failure this tool exists
+/// to end.
+pub fn update_reference_in_place(
+    doc: &mut Value,
+    id: &str,
+    patch: &Value,
+    merge: bool,
+) -> Result<Value, String> {
+    let refs = references_mut(doc)?;
+    let items = refs.get_mut("items").and_then(Value::as_object_mut).unwrap();
+    let current = items
+        .get(id)
+        .cloned()
+        .ok_or_else(|| format!("No reference '{}' in this document's library", id))?;
+
+    let patch_obj = patch
+        .as_object()
+        .ok_or("'item' must be a CSL-JSON object")?;
+
+    let merged = if merge {
+        let mut out = current.as_object().cloned().unwrap_or_default();
+        for (k, v) in patch_obj {
+            // An explicit null clears a field; anything else sets it. Without
+            // this there is no way to *remove* wrong metadata, only to overwrite
+            // it with something else.
+            if v.is_null() {
+                out.remove(k);
+            } else {
+                out.insert(k.clone(), v.clone());
+            }
+        }
+        Value::Object(out)
+    } else {
+        patch.clone()
+    };
+
+    // The id is the library key, so it is not the patch's to change. Renaming
+    // one would orphan every inline citation pointing at it.
+    let mut normalized = normalize_item(merged, id)
+        .ok_or("the updated reference is not a CSL-JSON object")?;
+    if let Some(obj) = normalized.as_object_mut() {
+        obj.insert("id".into(), json!(id));
+    }
+
+    items.insert(id.to_string(), normalized.clone());
+    Ok(normalized)
+}
+
+/// Remove one reference from the doc's JSON library and from `itemOrder` (the
+/// cold path). Returns whether it was there. Idempotent, so a replay under
+/// `mutate_with_retry` is safe.
+pub fn delete_reference_in_place(doc: &mut Value, id: &str) -> Result<bool, String> {
+    let refs = references_mut(doc)?;
+    let items = refs.get_mut("items").and_then(Value::as_object_mut).unwrap();
+    let existed = items.remove(id).is_some();
+
+    let order = refs.get_mut("itemOrder").and_then(Value::as_array_mut).unwrap();
+    order.retain(|v| v.as_str() != Some(id));
+    Ok(existed)
+}
+
 /// Build the `list_references` result payload from raw library parts (items map,
 /// display order, optional style). Shared by the cold JSON and resident live
 /// read paths.

--- a/relay/src/mcp/skills.rs
+++ b/relay/src/mcp/skills.rs
@@ -45,11 +45,26 @@ pub const CONTENT_CONTRACT: &str = r#"# DocuShark content contract (read before 
   scholarly content, cite real sources this way — don't hand-type a "References"
   list.** The formatted bibliography (`<div data-bibliography>`) is generated in
   the editor from the library, so you don't emit it yourself.
+- `data-label` is a CACHE, not the source of truth. A connected editor recomputes
+  it from the library entry in the active citation style and writes the result
+  back over whatever you wrote. So a citation that renders as the title instead
+  of "(Author, Year)" means the LIBRARY ENTRY is missing an author — repair it
+  with `update_reference` (fields merge; an explicit null clears one). Rewriting
+  the label alone will be overwritten the next time an editor opens the page.
+  `delete_reference` removes an entry, and refuses while it is still cited unless
+  you pass `force`.
 - Fields: define a reusable value with `set_fields`, then reference it as `{{name}}`
   (Markdown). If the doc won't be opened in an editor before you hand it off (e.g.
   export), bake the value into the stored HTML directly with
   `<span data-field data-name="name" data-label="value">value</span>` (format:"html")
   so it isn't blank.
+- Character entities: with format:"markdown" (the default) and format:"html",
+  named entities (`&mdash;`, `&le;`, `&aacute;`) and numeric ones (`&#275;`,
+  `&#x2014;`) both decode to the character. Literal Unicode is always safe too.
+  A literal ampersand in HTML must still be written `&amp;` — including inside a
+  URL, where `?a=1&sect;b` is read as a section sign exactly as a browser would
+  read it. After any format:"html" write, reading the page back is a cheap way to
+  confirm you got what you meant.
 - Every <img> needs a real src (a blob:, https:, or data: URL). A src-less image
   is dropped — it would crash the editor.
 - Tables must be rectangular *counting spans*: a <table> of <tr> rows whose

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -920,7 +920,7 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
         ToolDescriptor {
             name: "docushark_add_reference",
             description:
-                "Add one or more references (citations) to a document's reference library. Supply EITHER 'doi' (resolved via doi.org to CSL-JSON) OR 'items' (raw CSL-JSON object(s)). Deduplicates by DOI then id; returns the ids added and how many were skipped as duplicates. This populates the library. To CITE a reference inline, write <span data-citation data-ref-id=\"<id>\" data-label=\"(Author, Year)\">(Author, Year)</span> via set_prose (format:\"html\"), where <id> is an id returned here — for scholarly or researched content, prefer real citations over a hand-typed reference list. The formatted bibliography (<div data-bibliography>) is generated in the editor from the library. A connected editor sees new references on reload (references aren't live-synced yet). Refuses local (renderer-owned) documents.",
+                "Add one or more references (citations) to a document's reference library. Supply EITHER 'doi' (resolved via doi.org to CSL-JSON) OR 'items' (raw CSL-JSON object(s)). Deduplicates by DOI then id; returns the ids added and how many were skipped as duplicates. This populates the library. To CITE a reference inline, write <span data-citation data-ref-id=\"<id>\" data-label=\"(Author, Year)\">(Author, Year)</span> via set_prose (format:\"html\"), where <id> is an id returned here — for scholarly or researched content, prefer real citations over a hand-typed reference list. The data-label is a CACHE, not the source of truth: a connected editor recomputes it from the library entry in the active citation style and writes the result back, so a label that renders wrong means the LIBRARY ENTRY is wrong — most often a missing author, which makes the formatter fall back to a title-first form. Repair it with update_reference; rewriting the label alone will be overwritten. The formatted bibliography (<div data-bibliography>) is generated in the editor from the library. A connected editor sees new references on reload (references aren't live-synced yet). Refuses local (renderer-owned) documents.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -933,6 +933,37 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                     }
                 },
                 "required": ["docId"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark_update_reference",
+            description:
+                "Repair an existing reference in a document's library. Supply 'id' (the library key) and 'item' (CSL-JSON). By default the fields you supply are MERGED into the existing entry, and an explicit null clears a field; pass replace:true to swap the whole item instead. The 'id' cannot be changed here — renaming it would orphan every inline citation pointing at it. Fails if 'id' is not already in the library; use add_reference to create one. This is the tool for an inline citation that renders with the wrong text: the inline data-label is a cache the editor recomputes from the library, so fixing the entry here is what changes what readers see. Refuses local (renderer-owned) documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "id": {"type": "string", "description": "Id of the reference to repair, as returned by add_reference or list_references."},
+                    "item": {"type": "object", "description": "CSL-JSON fields to merge into the entry (or the whole replacement item when replace:true). An explicit null clears a field."},
+                    "replace": {"type": "boolean", "description": "Replace the whole item instead of merging the supplied fields. Default false."}
+                },
+                "required": ["docId", "id", "item"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark_delete_reference",
+            description:
+                "Remove a reference from a document's library, and from the bibliography generated off it. REFUSES by default when the reference is still cited inline, naming where (page id and block id) and how many, so the blast radius is visible before you act; pass force:true to delete anyway, which leaves those inline citations unresolved. To repair a wrong entry rather than remove it, use update_reference. Refuses local (renderer-owned) documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "id": {"type": "string", "description": "Id of the reference to remove."},
+                    "force": {"type": "boolean", "description": "Delete even though the reference is still cited inline, leaving those citations unresolved. Default false."}
+                },
+                "required": ["docId", "id"],
                 "additionalProperties": false
             }),
         },
@@ -1146,6 +1177,8 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark_reorder_prose_pages" => reorder_prose_pages(ctx, args),
         "docushark_list_references" => list_references(ctx, args),
         "docushark_add_reference" => add_reference(ctx, args),
+        "docushark_update_reference" => update_reference(ctx, args),
+        "docushark_delete_reference" => delete_reference(ctx, args),
         "docushark_list_fields" => list_fields(ctx, args),
         "docushark_set_fields" => set_fields(ctx, args),
         "docushark_get_skills" => get_skills(args),
@@ -4528,6 +4561,180 @@ fn add_reference(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String>
         result.as_object_mut().unwrap().insert("warning".into(), json!(w));
     }
 
+    Ok(ToolOutcome {
+        result,
+        changed_doc_id: Some(parsed.doc_id.clone()),
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct UpdateReferenceArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    id: String,
+    item: Value,
+    #[serde(default)]
+    replace: bool,
+}
+
+/// Repair one existing library entry. Mirrors `add_reference`'s resident /
+/// cold split, and reuses `insert_references` on the live path — it is a
+/// per-item LWW `set` that leaves `referenceOrder` alone for an id already
+/// present, which is exactly an update.
+///
+/// Both paths run the same `update_reference_in_place` merge, the resident one
+/// against a shim document built from the live library, so "merge" can only
+/// ever mean one thing. Two implementations of a merge rule is how the field
+/// set and the order list drift apart (JP-337).
+fn update_reference(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: UpdateReferenceArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    if let Some(handle) = resident_handle(ctx, &parsed.doc_id) {
+        let live = handle.references_json();
+        let mut shim = json!({ "references": { "items": live, "itemOrder": [] } });
+        let updated = super::citations::update_reference_in_place(
+            &mut shim,
+            &parsed.id,
+            &parsed.item,
+            !parsed.replace,
+        )?;
+        let framed = handle.insert_references(&[(parsed.id.clone(), updated.clone())]);
+        ctx.broadcast_update(&parsed.doc_id, framed);
+        return Ok(ToolOutcome {
+            result: json!({ "id": parsed.id, "item": updated }),
+            changed_doc_id: None,
+            change_detail: None,
+        });
+    }
+
+    let lock = {
+        let (doc, _) = fetch_doc(ctx, &parsed.doc_id)?;
+        lock_warning(&doc)
+    };
+    let updated = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let item = super::citations::update_reference_in_place(
+            doc,
+            &parsed.id,
+            &parsed.item,
+            !parsed.replace,
+        )?;
+        stamp_doc_modified(doc, now_ms());
+        Ok(item)
+    })?;
+
+    let mut result = json!({ "id": parsed.id, "item": updated });
+    if let Some(w) = lock {
+        result.as_object_mut().unwrap().insert("warning".into(), json!(w));
+    }
+    Ok(ToolOutcome {
+        result,
+        changed_doc_id: Some(parsed.doc_id.clone()),
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct DeleteReferenceArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    id: String,
+    #[serde(default)]
+    force: bool,
+}
+
+/// How many inline citations point at `ref_id`, and where.
+///
+/// Reads through `resolve_prose_pages`, so a resident document is censused
+/// against the live Y.Doc content a connected editor is actually looking at,
+/// not a stale snapshot — otherwise the refusal would clear a delete on the
+/// strength of prose that has since gained a citation.
+fn citation_sites(ctx: &ToolContext, doc_id: &DocId, doc: &Value, ref_id: &str) -> Vec<String> {
+    resolve_prose_pages(ctx, doc_id, doc)
+        .iter()
+        .flat_map(|(page_id, _name, _order, content)| {
+            crate::sync::collect_citations(content)
+                .into_iter()
+                .filter(|(rid, _)| rid == ref_id)
+                .map(|(_, block_id)| {
+                    if block_id.is_empty() {
+                        format!("page {}", page_id)
+                    } else {
+                        format!("page {} block {}", page_id, block_id)
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+/// Remove a library entry, refusing by default while it is still cited.
+///
+/// The refusal is the point of the tool. Deleting a cited reference is not
+/// wrong — sometimes it is exactly what a caller means — but doing it blind
+/// leaves inline citations pointing at nothing, and an agent has no way to see
+/// that from `list_references`. So the default answer names the sites and the
+/// count, and `force` is the caller saying they read it.
+fn delete_reference(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: DeleteReferenceArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    let (doc, _) = fetch_doc(ctx, &parsed.doc_id)?;
+    let sites = citation_sites(ctx, &parsed.doc_id, &doc, &parsed.id);
+    if !sites.is_empty() && !parsed.force {
+        // Cap the enumeration: a reference cited fifty times makes the point in
+        // the first few, and the count carries the rest.
+        let shown: Vec<&str> = sites.iter().take(5).map(String::as_str).collect();
+        let more = sites.len().saturating_sub(shown.len());
+        return Err(format!(
+            "Reference '{}' is still cited in {} place(s): {}{}. Deleting it would leave those \
+             citations unresolved. Remove the citations first, or pass force:true to delete anyway.",
+            parsed.id,
+            sites.len(),
+            shown.join(", "),
+            if more > 0 { format!(", and {} more", more) } else { String::new() },
+        ));
+    }
+
+    if let Some(handle) = resident_handle(ctx, &parsed.doc_id) {
+        let existed = handle.references_json().contains_key(&parsed.id);
+        if !existed {
+            return Err(format!("No reference '{}' in this document's library", parsed.id));
+        }
+        let framed = handle.delete_references(std::slice::from_ref(&parsed.id));
+        ctx.broadcast_update(&parsed.doc_id, framed);
+        return Ok(ToolOutcome {
+            result: json!({ "id": parsed.id, "deleted": true, "orphanedCitations": sites.len() }),
+            changed_doc_id: None,
+            change_detail: None,
+        });
+    }
+
+    let lock = {
+        let (doc, _) = fetch_doc(ctx, &parsed.doc_id)?;
+        lock_warning(&doc)
+    };
+    let existed = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let existed = super::citations::delete_reference_in_place(doc, &parsed.id)?;
+        if existed {
+            stamp_doc_modified(doc, now_ms());
+        }
+        Ok(existed)
+    })?;
+    if !existed {
+        return Err(format!("No reference '{}' in this document's library", parsed.id));
+    }
+
+    let mut result =
+        json!({ "id": parsed.id, "deleted": true, "orphanedCitations": sites.len() });
+    if let Some(w) = lock {
+        result.as_object_mut().unwrap().insert("warning".into(), json!(w));
+    }
     Ok(ToolOutcome {
         result,
         changed_doc_id: Some(parsed.doc_id.clone()),
@@ -8263,6 +8470,224 @@ mod tests {
         assert_eq!(listed.result["references"][0]["id"], json!("smith2020"));
         assert_eq!(listed.result["source"], json!("relay"));
         assert!(listed.changed_doc_id.is_none(), "a read must not nudge a reload");
+    }
+
+    #[test]
+    fn update_reference_merges_fields_by_default() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        dispatch(
+            &f.ctx(true),
+            "docushark_add_reference",
+            &json!({"docId": "doc1", "items": [
+                {"id": "reamer2024", "type": "book", "title": "A Title"},
+            ]}),
+        )
+        .unwrap();
+
+        // The reported case: an entry with no author, so the formatter falls
+        // back to a title-first label. Adding the author is the durable fix.
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark_update_reference",
+            &json!({"docId": "doc1", "id": "reamer2024",
+                    "item": {"author": [{"family": "Reamer"}]}}),
+        )
+        .unwrap();
+        assert_eq!(out.result["item"]["author"][0]["family"], json!("Reamer"));
+        // Merge, so untouched fields survive.
+        assert_eq!(out.result["item"]["title"], json!("A Title"));
+        assert_eq!(out.result["item"]["type"], json!("book"));
+
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("doc1".to_string()).unwrap();
+        let stored = f.relay.get_document(&ws, &doc_id).unwrap();
+        assert_eq!(stored["references"]["items"]["reamer2024"]["title"], json!("A Title"));
+        // An update is not an add: the order must not grow a second entry.
+        assert_eq!(stored["references"]["itemOrder"], json!(["reamer2024"]));
+    }
+
+    #[test]
+    fn update_reference_replaces_whole_item_when_asked() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        dispatch(
+            &f.ctx(true),
+            "docushark_add_reference",
+            &json!({"docId": "doc1", "items": [
+                {"id": "x", "type": "book", "title": "Wrong", "publisher": "Nobody"},
+            ]}),
+        )
+        .unwrap();
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark_update_reference",
+            &json!({"docId": "doc1", "id": "x", "replace": true,
+                    "item": {"type": "article-journal", "title": "Right"}}),
+        )
+        .unwrap();
+        assert_eq!(out.result["item"]["title"], json!("Right"));
+        assert!(
+            out.result["item"].get("publisher").is_none(),
+            "replace drops fields the new item omits: {:?}",
+            out.result["item"]
+        );
+        // The id is the library key, so it survives a replace that omits it.
+        assert_eq!(out.result["item"]["id"], json!("x"));
+    }
+
+    #[test]
+    fn update_reference_null_clears_a_field_and_unknown_id_is_refused() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        dispatch(
+            &f.ctx(true),
+            "docushark_add_reference",
+            &json!({"docId": "doc1", "items": [{"id": "x", "title": "T", "publisher": "P"}]}),
+        )
+        .unwrap();
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark_update_reference",
+            &json!({"docId": "doc1", "id": "x", "item": {"publisher": null}}),
+        )
+        .unwrap();
+        assert!(out.result["item"].get("publisher").is_none(), "explicit null clears");
+        assert_eq!(out.result["item"]["title"], json!("T"));
+
+        // Creating by typo is exactly the stranding this tool exists to end.
+        let err = dispatch(
+            &f.ctx(true),
+            "docushark_update_reference",
+            &json!({"docId": "doc1", "id": "nope", "item": {"title": "T"}}),
+        )
+        .unwrap_err();
+        assert!(err.contains("No reference 'nope'"), "{err}");
+    }
+
+    #[test]
+    fn delete_reference_refuses_while_cited_then_force_deletes() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        dispatch(
+            &f.ctx(true),
+            "docushark_add_reference",
+            &json!({"docId": "doc1", "items": [{"id": "knuth1997", "title": "TAOCP"}]}),
+        )
+        .unwrap();
+        let page = dispatch(
+            &f.ctx(true),
+            "docushark_add_prose_page",
+            &json!({"docId": "doc1", "content": "seed"}),
+        )
+        .unwrap();
+        let page_id = page.result["id"].as_str().unwrap().to_string();
+        dispatch(
+            &f.ctx(true),
+            "docushark_set_prose",
+            &json!({"docId": "doc1", "pageId": page_id, "format": "html", "content":
+                r#"<p>see <span data-citation data-ref-id="knuth1997" data-label="(Knuth, 1997)">(Knuth, 1997)</span></p>"#}),
+        )
+        .unwrap();
+
+        let err = dispatch(
+            &f.ctx(true),
+            "docushark_delete_reference",
+            &json!({"docId": "doc1", "id": "knuth1997"}),
+        )
+        .unwrap_err();
+        assert!(err.contains("still cited in 1 place"), "{err}");
+        assert!(err.contains("force"), "the refusal must say how to override: {err}");
+
+        // Still there — a refusal must not half-delete.
+        let listed =
+            dispatch(&f.ctx(true), "docushark_list_references", &json!({"docId": "doc1"})).unwrap();
+        assert_eq!(listed.result["count"], json!(1));
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark_delete_reference",
+            &json!({"docId": "doc1", "id": "knuth1997", "force": true}),
+        )
+        .unwrap();
+        assert_eq!(out.result["deleted"], json!(true));
+        assert_eq!(out.result["orphanedCitations"], json!(1));
+
+        let listed =
+            dispatch(&f.ctx(true), "docushark_list_references", &json!({"docId": "doc1"})).unwrap();
+        assert_eq!(listed.result["count"], json!(0));
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("doc1".to_string()).unwrap();
+        let stored = f.relay.get_document(&ws, &doc_id).unwrap();
+        assert_eq!(stored["references"]["itemOrder"], json!([]), "order must drop the id too");
+    }
+
+    #[test]
+    fn delete_reference_uncited_succeeds_without_force() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        dispatch(
+            &f.ctx(true),
+            "docushark_add_reference",
+            &json!({"docId": "doc1", "items": [{"id": "unused", "title": "T"}]}),
+        )
+        .unwrap();
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark_delete_reference",
+            &json!({"docId": "doc1", "id": "unused"}),
+        )
+        .unwrap();
+        assert_eq!(out.result["orphanedCitations"], json!(0));
+
+        let err = dispatch(
+            &f.ctx(true),
+            "docushark_delete_reference",
+            &json!({"docId": "doc1", "id": "unused"}),
+        )
+        .unwrap_err();
+        assert!(err.contains("No reference 'unused'"), "{err}");
+    }
+
+    #[test]
+    fn a_bibliographys_escaped_markup_is_not_a_citation() {
+        // `data-bib-html` carries ESCAPED markup that can itself contain
+        // citation spans. A text scan for `data-ref-id` would count those and
+        // refuse a delete that is actually safe, which is why the census reads
+        // the document model instead.
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        dispatch(
+            &f.ctx(true),
+            "docushark_add_reference",
+            &json!({"docId": "doc1", "items": [{"id": "ghost", "title": "T"}]}),
+        )
+        .unwrap();
+        let page = dispatch(
+            &f.ctx(true),
+            "docushark_add_prose_page",
+            &json!({"docId": "doc1", "content": "seed"}),
+        )
+        .unwrap();
+        let page_id = page.result["id"].as_str().unwrap().to_string();
+        dispatch(
+            &f.ctx(true),
+            "docushark_set_prose",
+            &json!({"docId": "doc1", "pageId": page_id, "format": "html", "content":
+                r#"<p>body</p><div data-bibliography data-bib-html="&lt;span data-citation data-ref-id=&quot;ghost&quot;&gt;x&lt;/span&gt;"></div>"#}),
+        )
+        .unwrap();
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark_delete_reference",
+            &json!({"docId": "doc1", "id": "ghost"}),
+        )
+        .unwrap();
+        assert_eq!(out.result["orphanedCitations"], json!(0), "escaped markup is not a citation");
     }
 
     #[test]

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -1089,6 +1089,8 @@ mod tests {
         assert!(names.contains(&"docushark_list_references"));
         assert!(names.contains(&"docushark_resolve_doi"));
         assert!(names.contains(&"docushark_add_reference"));
+        assert!(names.contains(&"docushark_update_reference"));
+        assert!(names.contains(&"docushark_delete_reference"));
         assert!(names.contains(&"docushark_list_fields"));
         assert!(names.contains(&"docushark_set_fields"));
         assert!(names.contains(&"docushark_get_skills"));
@@ -1100,7 +1102,7 @@ mod tests {
         assert!(names.contains(&"docushark_get_file"));
         assert!(names.contains(&"docushark_add_file"));
         assert!(names.contains(&"docushark_get_storage"));
-        assert_eq!(tools.len(), 43);
+        assert_eq!(tools.len(), 45);
     }
 
     // ---- JP-430 E3: add_file over the full transport (preflight + dispatch) ----

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -42,7 +42,7 @@ pub use prose_block::replace_block_in_html;
 pub use prose_block::{
     delete_block_in_html, insert_block_in_html, move_block_in_html, InsertSide, TargetSpec,
 };
-pub use prose_ids::{collect_block_ids, fill_block_ids};
+pub use prose_ids::{collect_block_ids, collect_citations, fill_block_ids};
 pub use prose_table::{
     edit_table_in_html, table_grid_in_html, GridView, Side as TableSide, TableEditOutcome,
     TableOp, TableSel,

--- a/relay/src/sync/prose_ids.rs
+++ b/relay/src/sync/prose_ids.rs
@@ -44,6 +44,53 @@ pub fn collect_block_ids(html: &str) -> Vec<String> {
     out
 }
 
+/// Every inline citation in `html`, as `(refId, blockId)` pairs in document
+/// order — the census `delete_reference` uses to decide whether removing a
+/// library entry would strand citations, and to say *where* if it would.
+///
+/// The `blockId` is the id of the nearest enclosing id-bearing block, or empty
+/// when that block carries none (ids are fill-on-write, so older content has
+/// gaps). Duplicates are kept: a reference cited three times reports three
+/// times, which is the number a caller wants when weighing a `force` delete.
+///
+/// Reads the document model rather than scanning the HTML for `data-ref-id`.
+/// That is not fastidiousness — a bibliography's `data-bib-html` attribute
+/// carries *escaped* markup that can itself contain citation spans, and a text
+/// scan would count those as live citations and refuse a delete that is
+/// actually safe.
+pub fn collect_citations(html: &str) -> Vec<(String, String)> {
+    fn walk(node: &PmNode, block_id: &str, out: &mut Vec<(String, String)>) {
+        // An id-bearing block relabels its subtree; anything else inherits.
+        let here = if TEXT_LEAVES.contains(&node.node_type.as_str()) {
+            node.attrs
+                .iter()
+                .find(|(k, _)| k == "id")
+                .map(|(_, v)| v.as_str())
+                .unwrap_or("")
+        } else {
+            block_id
+        };
+        for c in &node.children {
+            if let PmChild::Node(n) = c {
+                if n.node_type == "citationInline" {
+                    if let Some((_, ref_id)) = n.attrs.iter().find(|(k, _)| k == "refId") {
+                        if !ref_id.is_empty() {
+                            out.push((ref_id.clone(), here.to_string()));
+                        }
+                    }
+                }
+                walk(n, here, out);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    for b in &prose_parse::html_to_blocks(html) {
+        walk(b, "", &mut out);
+    }
+    out
+}
+
+
 /// Fill-only-if-absent: assign `mint()` to every id-bearing block whose id is
 /// missing, empty, collides with `taken` (ids already on the page outside this
 /// content), or duplicates an earlier block in this content — the first


### PR DESCRIPTION
The MCP surface could add references and never fix them. `add_reference` dedupes by DOI then id, so re-adding to correct metadata was **skipped as a duplicate** — silently, as a count, not an error. An entry entered with wrong metadata could not be repaired or removed except by hand in the editor. That is how a stranded reference happens, and it was reported from real agent usage.

## What ships

**`update_reference`** — merges the fields you supply by default, with an explicit `null` clearing one; `replace: true` swaps the whole item. The `id` is the library key and cannot be changed here: renaming it would orphan every inline citation pointing at it. An unknown id is **refused**, not created — silently upserting would turn a typo into a second stranded entry, which is the failure this tool exists to end.

**`delete_reference`** — refuses while the reference is still cited inline, naming the page and block sites and the count, and takes `force` to proceed anyway. Deleting a cited reference is sometimes exactly right; doing it blind is not, and `list_references` gives a caller no way to tell the difference.

## This also closes the citation-label report

A third report said inline `data-label` was unstable across write paths — that a full-page `set_prose` ran a citation-normalisation pass the anchored path skipped. **That diagnosis was wrong**, and finding out why changed the fix.

There is no normalisation pass in `set_prose`. The relay preserves `data-label` in code shared by *both* write paths, so the write path cannot be the variable. The rewrite is editor-side: the citation node view recomputes the label from the library and writes it back whenever it renders with the reference resolved, and returns early when the reference is missing. The real variable is whether a live editor had that node mounted.

That overwrite is correct — the label is a documented derived cache. The defect was the **contract**: `add_reference` told agents to write `data-label="(Author, Year)"` as though authoritative, while offering no way to fix the library entry underneath it (in the reported case, a missing author, which makes the CSL formatter fall back to a title-first form). Both halves are fixed here, in the tool description and the content contract. **No editor change.**

## The census reads the model, not the text

A bibliography's `data-bib-html` attribute carries **escaped** markup that can itself contain citation spans. A text scan for `data-ref-id` counts those and refuses a delete that is actually safe, so `collect_citations` walks the parsed document and looks for citation *nodes*.

`a_bibliographys_escaped_markup_is_not_a_citation` pins that, and it was **mutation-tested against exactly the wrong implementation** — swap the census for one that scans decoded attribute values and the test fails. Worth stating plainly: my first two mutation attempts appeared to pass, and the reason was that I had filtered the test run on `reference`, which does not match that test's name. It never ran. Targeted properly, the guard bites.

## Reuse worth noting

`delete_references` already existed on `DocHandle` (JP-468), and `insert_references` is a per-item LWW `set` that leaves `referenceOrder` alone for an id already present — which is an update. So the live path needed **no new Y.Doc surface**, and the slice came in smaller than planned. Both paths run the one `update_reference_in_place` merge, the resident one against a shim built from the live library, so "merge" can only ever mean one thing — two implementations of a merge rule is how JP-337 happened.

Cited-detection goes through the existing `resolve_prose_pages`, so a resident document is censused against the live content a connected editor is looking at, not a stale snapshot.

## Agent training

Rides along in the content contract: entity handling on both formats (per JP-497), `data-label` as a cache with the library as source of truth, the new repair verbs, and reading back after a `format:"html"` write.

## Verification

Full relay suite green: 823 lib tests plus every integration suite. Six new unit tests covering merge, replace, null-clears, unknown-id refusal, the cited refusal and its `force` override, idempotence of a second delete, and `itemOrder` not growing on update or retaining a deleted id. `cargo check --all-targets` clean. MCP surface change, so both tool references move with it; the `mcp-tools-doc-sync` drift guard passes at 46.

Assisted-by: Opus 5