### PR TITLE
Docs: mirrored pages import attachments (JP-499)

### DIFF
--- a/docs-site/guide/multi-page-documents.md
+++ b/docs-site/guide/multi-page-documents.md
@@ -48,8 +48,10 @@ the source connected from your account's Integrations page.
 
 To add one, click **+** on the prose tab bar and choose **New page from
 Notion…**, then search for the page you want and pick it. The content —
-headings, lists, tables, images — is imported as a read-only page, and the tab
-carries the source's icon so you can spot mirrored pages at a glance.
+headings, lists, tables, images, and file attachments — is imported as a
+read-only page, and the tab carries the source's icon so you can spot mirrored
+pages at a glance. Attachments come across as files you can open from the page,
+not just as their names.
 
 Mirrored pages behave differently from normal pages:
 


### PR DESCRIPTION
Companion to `docushark-web` [#122](https://github.com/JPE-Net-Technologies/docushark-web/pull/122), which wires Notion `file`/`pdf`/`audio`/`video` blocks to the prose file chip so a mirrored page carries the bytes rather than a sentence naming them.

`docs-site/guide/multi-page-documents.md` listed what a mirror imports as "headings, lists, tables, images". That is now understated, and understating it is the kind of thing a reader checks the docs specifically to find out — someone wondering whether their attachments came across would conclude they did not.

Separate PR because the change that makes it true is in the other repo, and a one-line docs correction should not be carried across a repo boundary inside an unrelated diff.

Docs site builds clean.

Assisted-by: Opus 5